### PR TITLE
Allow exposure to be a float + connect to exposure changed signal

### DIFF
--- a/micromanager_gui/_ui/micromanager_gui.ui
+++ b/micromanager_gui/_ui/micromanager_gui.ui
@@ -123,6 +123,9 @@
                <set>Qt::AlignCenter</set>
               </property>
               <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="value">
                <number>1</number>
               </property>
               <property name="maximum">

--- a/micromanager_gui/_ui/micromanager_gui.ui
+++ b/micromanager_gui/_ui/micromanager_gui.ui
@@ -115,7 +115,7 @@
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
-             <widget class="QSpinBox" name="exp_spinBox">
+             <widget class="QDoubleSpinBox" name="exp_spinBox">
               <property name="enabled">
                <bool>true</bool>
               </property>

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -57,7 +57,7 @@ class _MainUI:
     multid_tab: QtW.QWidget
     snap_channel_groupBox: QtW.QGroupBox
     snap_channel_comboBox: QtW.QComboBox
-    exp_spinBox: QtW.QSpinBox
+    exp_spinBox: QtW.QDoubleSpinBox
     snap_Button: QtW.QPushButton
     live_Button: QtW.QPushButton
     max_val_lineEdit: QtW.QLineEdit

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -343,7 +343,7 @@ class MainWindow(QtW.QWidget, _MainUI):
 
     def snap(self):
         self.stop_live()
-        self._mmc.setExposure(int(self.exp_spinBox.value()))
+        self._mmc.setExposure(self.exp_spinBox.value())
         self._mmc.snapImage()
         self.update_viewer(self._mmc.getImage())
 

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -348,7 +348,7 @@ class MainWindow(QtW.QWidget, _MainUI):
         self.update_viewer(self._mmc.getImage())
 
     def start_live(self):
-        self._mmc.startContinuousSequenceAcquisition(int(self.exp_spinBox.value()))
+        self._mmc.startContinuousSequenceAcquisition(self.exp_spinBox.value())
         self.streaming_timer = QTimer()
         self.streaming_timer.timeout.connect(self.update_viewer)
         self.streaming_timer.start(int(self.exp_spinBox.value()))

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -115,6 +115,7 @@ class MainWindow(QtW.QWidget, _MainUI):
         sig.XYStagePositionChanged.connect(self._on_xy_stage_position_changed)
         sig.stagePositionChanged.connect(self._on_stage_position_changed)
         sig.MDAFrameReady.connect(self._on_mda_frame)
+        sig.exposureChanged.connect(lambda name, exp: self.exp_spinBox.setValue(exp))
 
         # connect explorer
         self.explorer.new_frame.connect(self.add_frame_explorer)


### PR DESCRIPTION
Previously if you also had a separate client to `pymmcore-remote` that changed the exposure then the gui would not update and then would overwrite the  value.


There is a similar issue with `channels` (perhaps config groups generally) but I'm struggling with figuring out the `gets` and sets`. I would open an issue about this by it seems that issues are disabled on this repo currently.