### PR TITLE
Add callbacks to deal with setting channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ You can install `napari-micromanager` via [pip]:
 Contributions are very welcome. Tests can be run with [tox], please ensure
 the coverage at least stays the same before you submit a pull request.
 
+### Launching napari with plugin
+You can launch napari and automatically load this plugin using the `launch-dev.py` script:
+
+```bash
+python launch-dev.py
+```
+
+Alternatively you can run:
+
+```bash
+napari -w micromanager
+```
+
 ## License
 
 Distributed under the terms of the [BSD-3] license,

--- a/launch-dev.py
+++ b/launch-dev.py
@@ -1,10 +1,9 @@
 import napari
 
-
 v = napari.Viewer()
-dw, main_window = v.window.add_plugin_dock_widget('micromanager')
+dw, main_window = v.window.add_plugin_dock_widget("micromanager")
 
 core = main_window._mmc
-core.loadSystemConfiguration('micromanager_gui/demo_config.cfg')
+core.loadSystemConfiguration("micromanager_gui/demo_config.cfg")
 
 napari.run()

--- a/launch-dev.py
+++ b/launch-dev.py
@@ -1,0 +1,10 @@
+import napari
+
+
+v = napari.Viewer()
+dw, main_window = v.window.add_plugin_dock_widget('micromanager')
+
+core = main_window._mmc
+core.loadSystemConfiguration('micromanager_gui/demo_config.cfg')
+
+napari.run()

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -116,6 +116,7 @@ class MainWindow(QtW.QWidget, _MainUI):
         sig.stagePositionChanged.connect(self._on_stage_position_changed)
         sig.exposureChanged.connect(self._on_exp_change)
         sig.frameReady.connect(self._on_mda_frame)
+        sig.channelGroupChanged.connect(self._refresh_channel_list)
 
         # connect explorer
         self.explorer.new_frame.connect(self.add_frame_explorer)
@@ -234,8 +235,10 @@ class MainWindow(QtW.QWidget, _MainUI):
             self.objective_comboBox.addItems(self._mmc.getStateLabels("Objective"))
 
     def _refresh_channel_list(self):
-        if "Channel" in self._mmc.getAvailableConfigGroups():
-            channel_list = list(self._mmc.getAvailableConfigs("Channel"))
+        channel_group = self._mmc.getChannelGroup()
+        channel_group = "Channel" if channel_group=="" else channel_group
+        if channel_group in self._mmc.getAvailableConfigGroups():
+            channel_list = list(self._mmc.getAvailableConfigs(channel_group))
             self.snap_channel_comboBox.addItems(channel_list)
             self.explorer.scan_channel_comboBox.addItems(channel_list)
 

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -105,6 +105,8 @@ class MainWindow(QtW.QWidget, _MainUI):
         self.tabWidget.addTab(self.mda, "Multi-D Acquisition")
         self.tabWidget.addTab(self.explorer, "Sample Explorer")
 
+        self._channel_group = ""
+
         # # connect mmcore signals
         sig = self._mmc.events
 
@@ -116,7 +118,7 @@ class MainWindow(QtW.QWidget, _MainUI):
         sig.stagePositionChanged.connect(self._on_stage_position_changed)
         sig.exposureChanged.connect(self._on_exp_change)
         sig.frameReady.connect(self._on_mda_frame)
-        sig.channelGroupChanged.connect(self._refresh_channel_list)
+        sig.channelGroupChanged.connect(self._on_channel_group_changed)
 
         # connect explorer
         self.explorer.new_frame.connect(self.add_frame_explorer)
@@ -139,6 +141,11 @@ class MainWindow(QtW.QWidget, _MainUI):
         self.objective_comboBox.currentIndexChanged.connect(self.change_objective)
         self.bit_comboBox.currentIndexChanged.connect(self.bit_changed)
         self.bin_comboBox.currentIndexChanged.connect(self.bin_changed)
+
+    def _on_channel_group_changed(self, groupName: str):
+        self._channel_group = groupName
+        self._refresh_channel_list()
+
 
     def _on_exp_change(self, camera: str, exposure: float):
         self.exp_spinBox.setValue(exposure)
@@ -235,8 +242,7 @@ class MainWindow(QtW.QWidget, _MainUI):
             self.objective_comboBox.addItems(self._mmc.getStateLabels("Objective"))
 
     def _refresh_channel_list(self):
-        channel_group = self._mmc.getChannelGroup()
-        channel_group = "Channel" if channel_group=="" else channel_group
+        channel_group = "Channel" if self._channel_group=="" else self._channel_group
         if channel_group in self._mmc.getAvailableConfigGroups():
             channel_list = list(self._mmc.getAvailableConfigs(channel_group))
             self.snap_channel_comboBox.addItems(channel_list)

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from pymmcore_plus import CMMCorePlus, RemoteMMCore
@@ -16,7 +16,6 @@ from ._util import extend_array_for_index
 from .explore_sample import ExploreSample
 from .multid_widget import MultiDWidget
 
-from loguru import logger
 if TYPE_CHECKING:
     import napari.layers
     import napari.viewer
@@ -143,7 +142,6 @@ class MainWindow(QtW.QWidget, _MainUI):
         self.bin_comboBox.currentIndexChanged.connect(self.bin_changed)
         self.snap_channel_comboBox.currentTextChanged.connect(self._channel_changed)
 
-
     def _on_config_set(self, groupName: str, configName: str):
         if groupName == self._get_channel_group():
             self.snap_channel_comboBox.blockSignals(True)
@@ -244,7 +242,7 @@ class MainWindow(QtW.QWidget, _MainUI):
         if "Objective" in self._mmc.getLoadedDevices():
             self.objective_comboBox.addItems(self._mmc.getStateLabels("Objective"))
 
-    def _refresh_channel_list(self, channel_group: str=None):
+    def _refresh_channel_list(self, channel_group: str = None):
         if channel_group is None:
             channel_group = self._get_channel_group()
         if channel_group:
@@ -271,7 +269,7 @@ class MainWindow(QtW.QWidget, _MainUI):
             cd = self._mmc.getCameraDevice()
             self._mmc.setProperty(cd, "Binning", bins)
 
-    def _get_channel_group(self) -> Union[str, None]:
+    def _get_channel_group(self) -> str | None:
         """
         Get channelGroup falling back to Channel if not set, also
         check that this is an availableConfigGroup.


### PR DESCRIPTION
This PR adds two things
1. The development helper script from #27 and added a brief description to the readme.
2. bi-directional callbacks for when the channel is changed (also use the channelGroup when possible)

Closes: https://github.com/tlambert03/napari-micromanager/issues/26


Gets at part of #21, I didn't use the declarative mapping here because I think that this is the only config group that currently has an effect on the GUI. However, your proposed mapping will be helpful for the device properties.