### PR TITLE
Use `getLastImage` for live mode

### DIFF
--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -385,7 +385,7 @@ class MainWindow(QtW.QWidget, _MainUI):
         #       - are max and min_val_lineEdit updating in live mode?
         if data is None:
             try:
-                data = self._mmc.popNextImage()
+                data = self._mmc.getLastImage()
             except (RuntimeError, IndexError):
                 # circular buffer empty
                 return


### PR DESCRIPTION
This makes the display significantly less laggy when moving the stage around. Inspired by MMs implementation.

Inspired by https://github.com/micro-manager/micro-manager/blob/4a5d51ea76f89eaa6e74d0d772822701661aa76a/mmstudio/src/main/java/org/micromanager/internal/SnapLiveManager.java#L406