### PR TITLE
Small z-position fixes

### DIFF
--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -130,8 +130,6 @@ class MainWindow(QtW.QWidget, _MainUI):
         self.y_down_Button.clicked.connect(self.stage_y_down)
         self.up_Button.clicked.connect(self.stage_z_up)
         self.down_Button.clicked.connect(self.stage_z_down)
-        self.up_Button.clicked.connect(self.snap)
-        self.down_Button.clicked.connect(self.snap)
 
         self.snap_Button.clicked.connect(self.snap)
         self.live_Button.clicked.connect(self.toggle_live)

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -291,6 +291,8 @@ class MainWindow(QtW.QWidget, _MainUI):
         if self._mmc.getXYStageDevice():
             x, y = self._mmc.getXPosition(), self._mmc.getYPosition()
             self._on_xy_stage_position_changed(self._mmc.getXYStageDevice(), x, y)
+        if self._mmc.getFocusDevice():
+            self.z_lineEdit.setText(f"{self._mmc.getZPosition():.1f}")
 
     def _refresh_options(self):
         self._refresh_camera_options()


### PR DESCRIPTION
1. Autofill the z_line-edit when config loaded - otherwise it only updated once you moved the z stage
2. Don't snap when clicking the z up/down buttons (This feels like the correct behavior to me, otherwise you end up stopping live mode if you are already in it.)