### PR TITLE
simplify snap

### DIFF
--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -416,12 +416,6 @@ class MainWindow(QtW.QWidget, _MainUI):
 
     def snap(self):
         self.stop_live()
-
-        self._mmc.setExposure(self.exp_spinBox.value())
-
-        ch_group = self._mmc.getChannelGroup() or "Channel"
-        self._mmc.setConfig(ch_group, self.snap_channel_comboBox.currentText())
-
         self._mmc.snapImage()
         self.update_viewer(self._mmc.getImage())
 


### PR DESCRIPTION
Now that the callbacks on the GUI are all hooked up snap no longer needs to do expensive things like setting the config group. Also rather than stopping live mode to snap we should disable the ability to snap when live mode is on.