### PR TITLE
Use main window methods for mda channel group

### DIFF
--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, List, Tuple
 
 import numpy as np
 from pymmcore_plus import CMMCorePlus, RemoteMMCore
@@ -100,7 +100,7 @@ class MainWindow(QtW.QWidget, _MainUI):
         self._mmc = RemoteMMCore() if remote else CMMCorePlus()
 
         # tab widgets
-        self.mda = MultiDWidget(self._mmc)
+        self.mda = MultiDWidget(self._mmc, self)
         self.explorer = ExploreSample(self.viewer, self._mmc)
         self.tabWidget.addTab(self.mda, "Multi-D Acquisition")
         self.tabWidget.addTab(self.explorer, "Sample Explorer")

--- a/micromanager_gui/multid_widget.py
+++ b/micromanager_gui/multid_widget.py
@@ -78,8 +78,9 @@ class MultiDWidget(QtW.QWidget, _MultiDUI):
     # metadata associated with a given experiment
     SEQUENCE_META: dict[MDASequence, SequenceMeta] = {}
 
-    def __init__(self, mmcore: RemoteMMCore, parent=None):
+    def __init__(self, mmcore: RemoteMMCore, main, parent=None):
         self._mmc = mmcore
+        self._main_window = main
         super().__init__(parent)
         self.setup_ui()
 
@@ -146,10 +147,10 @@ class MultiDWidget(QtW.QWidget, _MultiDUI):
             self.channel_exp_spinBox.setRange(0, 10000)
             self.channel_exp_spinBox.setValue(100)
 
-            if "Channel" not in self._mmc.getAvailableConfigGroups():
-                raise ValueError("Could not find 'Channel' in the ConfigGroups")
-            channel_list = list(self._mmc.getAvailableConfigs("Channel"))
-            self.channel_comboBox.addItems(channel_list)
+            channel_group = self.main._get_channel_group()
+            if channel_group:
+                channel_list = list(self._mmc.getAvailableConfigs(channel_group))
+                self.channel_comboBox.addItems(channel_list)
 
             self.channel_tableWidget.setCellWidget(idx, 0, self.channel_comboBox)
             self.channel_tableWidget.setCellWidget(idx, 1, self.channel_exp_spinBox)


### PR DESCRIPTION
The main window has some good methods for being flexible about what user's have named config groups. So pass the main
window to the subwidgets in order to make this flexibility work there as well. This lets us be more robust to channel's in the MDA box.

But maybe instead of having the `main_window` object be the holder of all these methods it could make more sense to have a new object (`robustSettingGetter`?) that handles these sorts of things (of which there will surely be more) and then the main window can instantiate that object and pass it around where needed. Thoughts?