### PR TITLE
Use new `getChannelGroup getter from pymmc+

### DIFF
--- a/micromanager_gui/_util.py
+++ b/micromanager_gui/_util.py
@@ -9,6 +9,7 @@ from qtpy.QtWidgets import QWidget
 
 if TYPE_CHECKING:
     import useq
+    from typing import Union, List
 
 
 def get_devices_and_props(self):
@@ -98,8 +99,13 @@ def event_indices(event: useq.MDAEvent):
 
 
 @contextmanager
-def blockSignals(widget: QWidget):
-    orig_state = widget.signalsBlocked()
-    widget.blockSignals(True)
+def blockSignals(widgets: Union[QWidget, List[QWidget]]):
+    if not isinstance(widgets, (list, tuple)):
+        widgets = [widgets]
+    orig_states = []
+    for w in widgets:
+        orig_states.append(w.signalsBlocked())
+        w.blockSignals(True)
     yield
-    widget.blockSignals(orig_state)
+    for w, s in zip(widgets, orig_states):
+        w.blockSignals(s)

--- a/micromanager_gui/_util.py
+++ b/micromanager_gui/_util.py
@@ -9,7 +9,6 @@ from qtpy.QtWidgets import QWidget
 
 if TYPE_CHECKING:
     import useq
-    from typing import Union, List
 
 
 def get_devices_and_props(self):
@@ -99,7 +98,7 @@ def event_indices(event: useq.MDAEvent):
 
 
 @contextmanager
-def blockSignals(widgets: Union[QWidget, List[QWidget]]):
+def blockSignals(widgets: QWidget | list[QWidget]):
     if not isinstance(widgets, (list, tuple)):
         widgets = [widgets]
     orig_states = []

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -169,7 +169,7 @@ class MainWindow(QtW.QWidget, _MainUI):
         pb.exec()
 
     def _on_config_set(self, groupName: str, configName: str):
-        if groupName == self._get_channel_group():
+        if groupName == self._mmc.getOrGuessChannelGroup():
             with blockSignals(self.snap_channel_comboBox):
                 self.snap_channel_comboBox.setCurrentText(configName)
 
@@ -309,14 +309,14 @@ class MainWindow(QtW.QWidget, _MainUI):
 
     def _refresh_channel_list(self, channel_group: str = None):
         if channel_group is None:
-            channel_group = self._get_channel_group()
+            channel_group = self._mmc.getOrGuessChannelGroup()
         if channel_group:
             channel_list = list(self._mmc.getAvailableConfigs(channel_group))
             with blockSignals(self.snap_channel_comboBox):
                 self.snap_channel_comboBox.clear()
                 self.snap_channel_comboBox.addItems(channel_list)
                 self.snap_channel_comboBox.setCurrentText(
-                    self._mmc.getCurrentConfig("Channel")
+                    self._mmc.getCurrentConfig(channel_group)
                 )
 
     def _refresh_positions(self):
@@ -343,20 +343,10 @@ class MainWindow(QtW.QWidget, _MainUI):
             cd = self._mmc.getCameraDevice()
             self._mmc.setProperty(cd, "Binning", bins)
 
-    def _get_channel_group(self) -> str | None:
-        """
-        Get channelGroup falling back to Channel if not set, also
-        check that this is an availableConfigGroup.
-        """
-        chan_group = self._mmc.getChannelGroup()
-        if chan_group == "":
-            # not set in core. Try "Channel" as a fallback
-            chan_group = "Channel"
-        if chan_group in self._mmc.getAvailableConfigGroups():
-            return chan_group
-
     def _channel_changed(self, newChannel: str):
-        self._mmc.setConfig(self._get_channel_group(), newChannel)
+        channel_group = self._mmc.getOrGuessChannelGroup()
+        if channel_group:
+            self._mmc.setConfig(channel_group, newChannel)
 
     def _on_xy_stage_position_changed(self, name, x, y):
         self.x_lineEdit.setText(f"{x:.1f}")
@@ -504,7 +494,7 @@ class MainWindow(QtW.QWidget, _MainUI):
     def toggle_live(self, event=None):
         if self.streaming_timer is None:
 
-            ch_group = self._mmc.getChannelGroup() or "Channel"
+            ch_group = self._mmc.getOrGuessChannelGroup()
             self._mmc.setConfig(ch_group, self.snap_channel_comboBox.currentText())
 
             self.start_live()

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -259,11 +259,16 @@ class MainWindow(QtW.QWidget, _MainUI):
         self._mmc.unloadAllDevices()  # unload all devicies
         print(f"Loaded Devices: {self._mmc.getLoadedDevices()}")
 
-        # clear spinbox/combobox
-        self.objective_comboBox.clear()
-        self.bin_comboBox.clear()
-        self.bit_comboBox.clear()
-        self.snap_channel_comboBox.clear()
+        # clear spinbox/combobox without accidently setting properties
+        boxes = [
+            self.objective_comboBox,
+            self.bin_comboBox,
+            self.bit_comboBox,
+            self.snap_channel_comboBox,
+        ]
+        with blockSignals(boxes):
+            for box in boxes:
+                box.clear()
 
         file_dir = QtW.QFileDialog.getOpenFileName(self, "", "⁩", "cfg(*.cfg)")
         self.cfg_LineEdit.setText(str(file_dir[0]))

--- a/micromanager_gui/multid_widget.py
+++ b/micromanager_gui/multid_widget.py
@@ -146,10 +146,10 @@ class MultiDWidget(QtW.QWidget, _MultiDUI):
             self.channel_exp_spinBox.setRange(0, 10000)
             self.channel_exp_spinBox.setValue(100)
 
-            if "Channel" not in self._mmc.getAvailableConfigGroups():
-                raise ValueError("Could not find 'Channel' in the ConfigGroups")
-            channel_list = list(self._mmc.getAvailableConfigs("Channel"))
-            self.channel_comboBox.addItems(channel_list)
+            channel_group = self._mmc.getOrGuessChannelGroup()
+            if channel_group:
+                channel_list = list(self._mmc.getAvailableConfigs(channel_group))
+                self.channel_comboBox.addItems(channel_list)
 
             self.channel_tableWidget.setCellWidget(idx, 0, self.channel_comboBox)
             self.channel_tableWidget.setCellWidget(idx, 1, self.channel_exp_spinBox)


### PR DESCRIPTION
Follow up to https://github.com/tlambert03/napari-micromanager/pull/54


Also:

- Expanded the functionality of `blockSignals` to take a list of widgets.
- Be more careful when loading a config that we don't accidentally set properties when `clear`ing the spinboxes