### PR TITLE
set channel group using new getOrGuessChannelGroup() method from pymmcore-plus

### DIFF
--- a/micromanager_gui/_util.py
+++ b/micromanager_gui/_util.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import numpy as np
-from qtpy.QtWidgets import QWidget
+from qtpy.QtWidgets import QComboBox, QDialog, QHBoxLayout, QLabel, QPushButton, QWidget
 
 if TYPE_CHECKING:
     import useq
@@ -103,3 +103,25 @@ def blockSignals(widget: QWidget):
     widget.blockSignals(True)
     yield
     widget.blockSignals(orig_state)
+
+
+class SelectDeviceFromCombobox(QDialog):
+    def __init__(self, obj_dev: list, func: Callable, label: str, parent=None):
+        super().__init__(parent)
+
+        self.func = func
+
+        self.setLayout(QHBoxLayout())
+        self.label = QLabel()
+        self.label.setText(label)
+        self.combobox = QComboBox()
+        self.combobox.addItems(obj_dev)
+        self.button = QPushButton("Set")
+        self.button.clicked.connect(self._on_click)
+
+        self.layout().addWidget(self.label)
+        self.layout().addWidget(self.combobox)
+        self.layout().addWidget(self.button)
+
+    def _on_click(self):
+        self.func([self.combobox.currentText()])

--- a/micromanager_gui/_util.py
+++ b/micromanager_gui/_util.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
+from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QComboBox, QDialog, QHBoxLayout, QLabel, QPushButton, QWidget
 
 if TYPE_CHECKING:
@@ -111,10 +112,10 @@ def blockSignals(widgets: QWidget | list[QWidget]):
 
 
 class SelectDeviceFromCombobox(QDialog):
-    def __init__(self, obj_dev: list, func: Callable, label: str, parent=None):
-        super().__init__(parent)
+    val_changed = Signal(str)
 
-        self.func = func
+    def __init__(self, obj_dev: list, label: str, parent=None):
+        super().__init__(parent)
 
         self.setLayout(QHBoxLayout())
         self.label = QLabel()
@@ -129,4 +130,4 @@ class SelectDeviceFromCombobox(QDialog):
         self.layout().addWidget(self.button)
 
     def _on_click(self):
-        self.func([self.combobox.currentText()])
+        self.val_changed.emit(self.combobox.currentText())

--- a/micromanager_gui/explore_sample.py
+++ b/micromanager_gui/explore_sample.py
@@ -186,10 +186,10 @@ class ExploreSample(QtW.QWidget):
             self.channel_explorer_exp_spinBox.setRange(0, 10000)
             self.channel_explorer_exp_spinBox.setValue(100)
 
-            if "Channel" not in self._mmc.getAvailableConfigGroups():
-                raise ValueError("Could not find 'Channel' in the ConfigGroups")
-            channel_list = list(self._mmc.getAvailableConfigs("Channel"))
-            self.channel_explorer_comboBox.addItems(channel_list)
+            channel_group = self._mmc.getChannelGroup()
+            if channel_group:
+                channel_list = list(self._mmc.getAvailableConfigs(channel_group))
+                self.channel_explorer_comboBox.addItems(channel_list)
 
             self.channel_explorer_tableWidget.setCellWidget(
                 idx, 0, self.channel_explorer_comboBox

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -307,17 +307,37 @@ class MainWindow(QtW.QWidget, _MainUI):
                     self._mmc.getStateLabel("Objective")
                 )
 
-    def _refresh_channel_list(self, channel_group: str = None):
-        if channel_group is None:
-            channel_group = self._get_channel_group()
-        if channel_group:
-            channel_list = list(self._mmc.getAvailableConfigs(channel_group))
-            with blockSignals(self.snap_channel_comboBox):
-                self.snap_channel_comboBox.clear()
-                self.snap_channel_comboBox.addItems(channel_list)
-                self.snap_channel_comboBox.setCurrentText(
-                    self._mmc.getCurrentConfig("Channel")
-                )
+    # def _refresh_channel_list(self, channel_group: str = None):
+    #     guessed_channel_list = self._mmc.getOrGuessChannelGroup()
+
+    #     if not guessed_channel_list:
+    #         return
+
+    #     if len(guessed_channel_list) == 1:
+    #         self._mmc.setChannelGroup(guessed_channel_list[0])
+    #     else:
+    #          # if guessed_channel_list has more than 1 possible channel group,
+    #          # you can select the correct one through a combobox
+    #          obj = SelectDeviceFromCombobox(
+    #              guessed_channel_list,
+    #              self._set_objective_device,
+    #              "Select Objective Device:",
+    #              self,
+    #          )
+    #          obj.show()
+
+    # def _set_channel_group(self, guessed_channel_list: list):
+
+    #     if channel_group is None:
+    #         channel_group = self._get_channel_group()
+    #     if channel_group:
+    #         channel_list = list(self._mmc.getAvailableConfigs(channel_group))
+    #         with blockSignals(self.snap_channel_comboBox):
+    #             self.snap_channel_comboBox.clear()
+    #             self.snap_channel_comboBox.addItems(channel_list)
+    #             self.snap_channel_comboBox.setCurrentText(
+    #                 self._mmc.getCurrentConfig("Channel")
+    #             )
 
     def _refresh_positions(self):
         if self._mmc.getXYStageDevice():

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -14,7 +14,12 @@ from qtpy.QtGui import QColor, QIcon
 
 from ._illumination import IlluminationDialog
 from ._saving import save_sequence
-from ._util import blockSignals, event_indices, extend_array_for_index
+from ._util import (
+    SelectDeviceFromCombobox,
+    blockSignals,
+    event_indices,
+    extend_array_for_index,
+)
 from .explore_sample import ExploreSample
 from .multid_widget import MultiDWidget, SequenceMeta
 from .prop_browser import PropBrowser
@@ -123,8 +128,6 @@ class MainWindow(QtW.QWidget, _MainUI):
         sig.stagePositionChanged.connect(self._on_stage_position_changed)
         sig.exposureChanged.connect(self._on_exp_change)
         sig.frameReady.connect(self._on_mda_frame)
-        sig.channelGroupChanged.connect(self._refresh_channel_list)
-        sig.configSet.connect(self._on_config_set)
 
         # connect buttons
         self.load_cfg_Button.clicked.connect(self.load_cfg)
@@ -159,6 +162,10 @@ class MainWindow(QtW.QWidget, _MainUI):
         self.viewer.layers.selection.events.active.connect(self.update_max_min)
         self.viewer.dims.events.current_step.connect(self.update_max_min)
 
+        @sig.configSet.connect
+        def _on_cfg_set(group: str, preset: str):
+            print(f"New group cfg set: {group} -> {preset}")
+
     def illumination(self):
         if not hasattr(self, "_illumination"):
             self._illumination = IlluminationDialog(self._mmc, self)
@@ -167,11 +174,6 @@ class MainWindow(QtW.QWidget, _MainUI):
     def _show_prop_browser(self):
         pb = PropBrowser(self._mmc, self)
         pb.exec()
-
-    def _on_config_set(self, groupName: str, configName: str):
-        if groupName == self._get_channel_group():
-            with blockSignals(self.snap_channel_comboBox):
-                self.snap_channel_comboBox.setCurrentText(configName)
 
     def _set_enabled(self, enabled):
         self.objective_groupBox.setEnabled(enabled)
@@ -307,37 +309,35 @@ class MainWindow(QtW.QWidget, _MainUI):
                     self._mmc.getStateLabel("Objective")
                 )
 
-    # def _refresh_channel_list(self, channel_group: str = None):
-    #     guessed_channel_list = self._mmc.getOrGuessChannelGroup()
+    def _refresh_channel_list(self):
+        guessed_channel_list = self._mmc.getOrGuessChannelGroup()
 
-    #     if not guessed_channel_list:
-    #         return
+        if not guessed_channel_list:
+            return
 
-    #     if len(guessed_channel_list) == 1:
-    #         self._mmc.setChannelGroup(guessed_channel_list[0])
-    #     else:
-    #          # if guessed_channel_list has more than 1 possible channel group,
-    #          # you can select the correct one through a combobox
-    #          obj = SelectDeviceFromCombobox(
-    #              guessed_channel_list,
-    #              self._set_objective_device,
-    #              "Select Objective Device:",
-    #              self,
-    #          )
-    #          obj.show()
+        if len(guessed_channel_list) == 1:
+            self._set_channel_group(guessed_channel_list)
+        else:
+            # if guessed_channel_list has more than 1 possible channel group,
+            # you can select the correct one through a combobox
+            ch = SelectDeviceFromCombobox(
+                guessed_channel_list,
+                self._set_channel_group,
+                "Select Channel Group:",
+                self,
+            )
+            ch.show()
 
-    # def _set_channel_group(self, guessed_channel_list: list):
-
-    #     if channel_group is None:
-    #         channel_group = self._get_channel_group()
-    #     if channel_group:
-    #         channel_list = list(self._mmc.getAvailableConfigs(channel_group))
-    #         with blockSignals(self.snap_channel_comboBox):
-    #             self.snap_channel_comboBox.clear()
-    #             self.snap_channel_comboBox.addItems(channel_list)
-    #             self.snap_channel_comboBox.setCurrentText(
-    #                 self._mmc.getCurrentConfig("Channel")
-    #             )
+    def _set_channel_group(self, guessed_channel_list: list):
+        channel_group = guessed_channel_list[0]
+        self._mmc.setChannelGroup(channel_group)
+        channel_list = self._mmc.getAvailableConfigs(channel_group)
+        with blockSignals(self.snap_channel_comboBox):
+            self.snap_channel_comboBox.clear()
+            self.snap_channel_comboBox.addItems(channel_list)
+            self.snap_channel_comboBox.setCurrentText(
+                self._mmc.getCurrentConfig(channel_group)
+            )
 
     def _refresh_positions(self):
         if self._mmc.getXYStageDevice():
@@ -363,20 +363,8 @@ class MainWindow(QtW.QWidget, _MainUI):
             cd = self._mmc.getCameraDevice()
             self._mmc.setProperty(cd, "Binning", bins)
 
-    def _get_channel_group(self) -> str | None:
-        """
-        Get channelGroup falling back to Channel if not set, also
-        check that this is an availableConfigGroup.
-        """
-        chan_group = self._mmc.getChannelGroup()
-        if chan_group == "":
-            # not set in core. Try "Channel" as a fallback
-            chan_group = "Channel"
-        if chan_group in self._mmc.getAvailableConfigGroups():
-            return chan_group
-
     def _channel_changed(self, newChannel: str):
-        self._mmc.setConfig(self._get_channel_group(), newChannel)
+        self._mmc.setConfig(self._mmc.getChannelGroup(), newChannel)
 
     def _on_xy_stage_position_changed(self, name, x, y):
         self.x_lineEdit.setText(f"{x:.1f}")

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import napari
 import numpy as np
+from loguru import logger
 from pymmcore_plus import CMMCorePlus, RemoteMMCore
 from qtpy import QtWidgets as QtW
 from qtpy import uic
@@ -164,7 +165,7 @@ class MainWindow(QtW.QWidget, _MainUI):
 
         @sig.configSet.connect
         def _on_cfg_set(group: str, preset: str):
-            print(f"New group cfg set: {group} -> {preset}")
+            logger.debug(f"New group cfg set: {group} -> {preset}")
 
     def illumination(self):
         if not hasattr(self, "_illumination"):

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -332,7 +332,6 @@ class MainWindow(QtW.QWidget, _MainUI):
             # you can select the correct one through a combobox
             ch = SelectDeviceFromCombobox(
                 guessed_channel_list,
-                self._set_channel_group,
                 "Select Channel Group:",
                 self,
             )

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -326,7 +326,7 @@ class MainWindow(QtW.QWidget, _MainUI):
             return
 
         if len(guessed_channel_list) == 1:
-            self._set_channel_group(guessed_channel_list)
+            self._set_channel_group(guessed_channel_list[0])
         else:
             # if guessed_channel_list has more than 1 possible channel group,
             # you can select the correct one through a combobox
@@ -335,10 +335,11 @@ class MainWindow(QtW.QWidget, _MainUI):
                 "Select Channel Group:",
                 self,
             )
+            ch.val_changed.connect(self._set_channel_group)
             ch.show()
 
-    def _set_channel_group(self, guessed_channel_list: list):
-        channel_group = guessed_channel_list[0]
+    def _set_channel_group(self, guessed_channel: str):
+        channel_group = guessed_channel
         self._mmc.setChannelGroup(channel_group)
         channel_list = self._mmc.getAvailableConfigs(channel_group)
         with blockSignals(self.snap_channel_comboBox):

--- a/micromanager_gui/multid_widget.py
+++ b/micromanager_gui/multid_widget.py
@@ -213,7 +213,7 @@ class MultiDWidget(QtW.QWidget, _MultiDUI):
             self.channel_exp_spinBox.setRange(0, 10000)
             self.channel_exp_spinBox.setValue(100)
 
-            channel_group = self._mmc.getOrGuessChannelGroup()
+            channel_group = self._mmc.getChannelGroup()
             if channel_group:
                 channel_list = list(self._mmc.getAvailableConfigs(channel_group))
                 self.channel_comboBox.addItems(channel_list)

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,3 +68,4 @@ ignore =
     micromanager_gui/Micro-Manager-*
     launch-dev.py
     tox.ini
+    codecov.yml

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     napari
     scikit-image
     tqdm
-    pymmcore-plus >=0.1.5
+    pymmcore-plus >=0.1.8
     useq-schema >=0.1.0
     magicgui >=0.3.0
 


### PR DESCRIPTION
As explained in [tlambert03/pymmcore-plus/PR#67](https://github.com/tlambert03/pymmcore-plus/pull/67), the new `getOrGuessChannelGroup()` method from `pymmcore-plus` will return a `list` instead of a single string. As for the objective device (#43):

- `_refresh_channel_list()` -> it uses the `getOrGuessChannelGroup()` method in `pymmcore-plus` to get a list of possible channel group configurations.

    - If there is only one element in the list (only 1 possible guessed channel group configuration), then the channel group is set through the new `_set_channel_group()` method.
    - If there are more elements in the list, it lets you chose the correct guessed channel group configuration through a magicgui combobox (`SelectDeviceFromCombobox()` class in `_util.py`)