### PR TITLE
use threads for snap

### DIFF
--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -6,13 +6,13 @@ from typing import TYPE_CHECKING
 
 import napari
 import numpy as np
-from napari.qt.threading import thread_worker
 from pymmcore_plus import CMMCorePlus, RemoteMMCore
 from pymmcore_plus._util import find_micromanager
 from qtpy import QtWidgets as QtW
 from qtpy import uic
 from qtpy.QtCore import QSize, QTimer
 from qtpy.QtGui import QColor, QIcon
+from superqt.utils import create_worker
 
 from ._camera_roi import CameraROI
 from ._illumination import IlluminationDialog
@@ -605,13 +605,11 @@ class MainWindow(QtW.QWidget, _MainUI):
         self.stop_live()
 
         # snap in a thread so we don't freeze UI when using process local mmc
-        @thread_worker(
-            connect={"finished": lambda: self.update_viewer(self._mmc.getImage())}
+        create_worker(
+            self._mmc.snapImage,
+            _connect={"finished": lambda: self.update_viewer(self._mmc.getImage())},
+            _start_thread=True,
         )
-        def snap_worker():
-            self._mmc.snapImage()
-
-        snap_worker()
 
     def start_live(self):
         self._mmc.startContinuousSequenceAcquisition(self.exp_spinBox.value())


### PR DESCRIPTION
Use a thread when snapping to prevent the UI freezing when using `CMMCorePlus`.

I tried to use the napari generator threading example to only need to spawn one worker, but I couldn't consistently get it to not accidentally snap twice so spawning a new one everytime (unless this is a bad thing?)

I also tried to add the option of psasing and existing core object in to allow launching napari from another script and still having access to the core object (aside from `main_window._mmc` but I think that this is limited by https://github.com/napari/napari/issues/1211. So maybe it would be good for the process local pymmcore-plus to have a mechanism to get an already existing CMMCore object if one exists?


The other issue I'm noticing that probably will need fixing on pymmcore-plus is that now that we've introduced threading you can do bad things like
1. snap an image with a long exposure
2. change some other setting (intentionally or accidentally) that send a command to mmc
That's bad in the sense that it would mess up your image, but also I'm not sure how `MMCore` would even behave there, potentially poorly I imagine.
For example if you mash the `snap` button and then hit the `live` button you get errors like this:
```
    600 @thread_worker(
    601     connect={"finished": lambda: self.update_viewer(self._mmc.getImage())}
    602 )
    603 def snap_worker():
--> 604     self._mmc.snapImage()
        self._mmc = <CMMCorePlus at 0x7fab9e0e2f40>
        self = <micromanager_gui.main_window.MainWindow object at 0x7fabb2ddc3a0>

RuntimeError: This operation can not be executed while sequence acquisition is running.
```

so there may need to be some sort of locking mechanism on pymmcore-plus?
