### PR TITLE
napari reset view in explorer

### DIFF
--- a/micromanager_gui/explore_sample.py
+++ b/micromanager_gui/explore_sample.py
@@ -138,6 +138,13 @@ class ExploreSample(QtW.QWidget):
         self.viewer.add_image(
             image, name=layer_name, blending="additive", translate=(y, x), metadata=meta
         )
+
+        zoom_out_factor = (
+            self.scan_size_r
+            if self.scan_size_r >= self.scan_size_c
+            else self.scan_size_c
+        )
+        self.viewer.camera.zoom = 1 / zoom_out_factor
         self.viewer.reset_view()
 
     def _on_mda_finished(self, sequence: useq.MDASequence):


### PR DESCRIPTION
Reset the napari viewer `zoom` and `view` every time a frame is acquired when using `explore_sample.py'.

https://user-images.githubusercontent.com/70725613/155626791-f0798251-57c4-4418-96ee-36aead71d641.mov


