### PR TITLE
Ensure `_on_mda_frame` is called in main thread

### DIFF
--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -11,7 +11,7 @@ from pymmcore_plus._util import find_micromanager
 from qtpy import QtWidgets as QtW
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtGui import QColor, QIcon
-from superqt.utils import create_worker
+from superqt.utils import create_worker, ensure_main_thread
 
 from ._camera_roi import CameraROI
 from ._gui_objects._mm_widget import MicroManagerWidget
@@ -308,6 +308,7 @@ class MainWindow(MicroManagerWidget):
         """ "create temp folder and block gui when mda starts."""
         self._set_enabled(False)
 
+    @ensure_main_thread
     def _on_mda_frame(self, image: np.ndarray, event: useq.MDAEvent):
         meta = self.mda.SEQUENCE_META.get(event.sequence) or SequenceMeta()
 


### PR DESCRIPTION
Fixes #113 

This one decorator (a brilliant contribution to superqt from @czaki) is all that was needed to fix the errors that happen when the `CMMCore.events` object is backed by `psygnal.Signal` instead of `QtCore.Signal`.

Some notes on how I debugged this:
1. I ran the script provided in #113 using `NAPARI_DEBUG_EVENTS=1 python script.py`
2. that showed that it was consistently the `viewer.add_image()` call in `_on_mda_frame` that caused the crash:
   ```py
    LayerList.events.inserting(index=0)
    was triggered by Viewer.add_image(), via:
    ".../site-packages/napari/utils/events/containers/_evented_list.py", line 177, in LayerList.insert
    ".../site-packages/napari/utils/events/containers/_selectable_list.py", line 65, in LayerList.insert
    ".../site-packages/napari/components/layerlist.py", line 90, in LayerList.insert
    ".../python/_collections_abc.py", line 1073, in LayerList.append
    ".../site-packages/napari/components/viewer_model.py", line 732, in Viewer.add_image
    "/Users/talley/Dropbox (HMS)/Python/forks/napari-micromanager/micromanager_gui/main_window.py", line 348, in MainWindow._on_mda_frame
    "/Users/talley/Dropbox (HMS)/Python/pymmcore-plus/pymmcore_plus/core/_mmcore_plus.py", line 533, in CMMCorePlus._mda
    ".../python/threading.py", line 910, in Thread.run
   ```
4. The error (`WARNING: QObject::connect: Cannot queue arguments of type 'QVector<int>'`) suggests that Qt is trying to communicate across threads.  However, by this point (when we're trying to manipulate the guy) we need to be back in the main thread.
5. Enter @Czaki's magic decorator, that ensures our callback is called in the QApplication's thread.

thanks @Czaki!