### PR TITLE
Generic device widget, and StateDeviceWidget

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,8 @@ coverage:
   status:
     project:
       default:
-        # basic
         target: auto
         threshold: 2%
-    patch: off
+    patch:
+      default:
+        target: 80%

--- a/micromanager_gui/_gui_objects/_device_widget.py
+++ b/micromanager_gui/_gui_objects/_device_widget.py
@@ -24,9 +24,8 @@ class DeviceWidget(QWidget):
     @classmethod
     def for_device(cls, label: str):
         core = CMMCorePlus.instance()
-        dt = core.getDeviceType("Objective")
         _map = {DeviceType.StateDevice: StateDeviceWidget}
-        return _map[dt](label)
+        return _map[core.getDeviceType(label)](label)
 
 
 class StateDeviceWidget(DeviceWidget):

--- a/micromanager_gui/_gui_objects/_device_widget.py
+++ b/micromanager_gui/_gui_objects/_device_widget.py
@@ -52,7 +52,7 @@ class StateDeviceWidget(DeviceWidget):
         self._mmc.setState(self._device_label, index)
 
     def _disconnect(self):
-        self._mmc.events.propertyChanged.connect(self._on_prop_change)
+        self._mmc.events.propertyChanged.disconnect(self._on_prop_change)
 
     def _on_prop_change(self, dev_label: str, prop: str, value: Any):
         if dev_label == self._device_label:

--- a/micromanager_gui/_gui_objects/_device_widget.py
+++ b/micromanager_gui/_gui_objects/_device_widget.py
@@ -2,6 +2,7 @@ from typing import Any, Optional, Tuple, TypeVar
 
 from pymmcore_plus import DeviceType
 from qtpy.QtWidgets import QComboBox, QHBoxLayout, QWidget
+from superqt.utils import signals_blocked
 
 from .._core import get_core_singleton
 
@@ -65,15 +66,13 @@ class StateDeviceWidget(DeviceWidget):
         # a property change event?
         print("PROP CHANGE", locals())
         if dev_label == self._device_label:
-            pre = self._combo.blockSignals(True)
-            self._combo.setCurrentText(value)
-            self._combo.blockSignals(pre)
+            with signals_blocked(self._combo):
+                self._combo.setCurrentText(value)
 
     def _refresh_combo_choices(self):
-        pre = self._combo.blockSignals(True)
-        self._combo.clear()
-        self._combo.addItems(self.stateLabels())
-        self._combo.blockSignals(pre)
+        with signals_blocked(self._combo):
+            self._combo.clear()
+            self._combo.addItems(self.stateLabels())
 
     def state(self) -> int:
         return self._mmc.getState(self._device_label)

--- a/micromanager_gui/_gui_objects/_device_widget.py
+++ b/micromanager_gui/_gui_objects/_device_widget.py
@@ -19,7 +19,7 @@ class DeviceWidget(QWidget):
         self._mmc = CMMCorePlus.instance()
 
     def deviceName(self) -> str:
-        return self._mmc.getDeviceName()
+        return self._mmc.getDeviceName(self._device_label)
 
     @classmethod
     def for_device(cls, label: str):

--- a/micromanager_gui/_gui_objects/_device_widget.py
+++ b/micromanager_gui/_gui_objects/_device_widget.py
@@ -72,6 +72,11 @@ class DeviceWidget(QWidget):
         """
         dev_type = get_core_singleton().getDeviceType(device_label)
         _map = {DeviceType.StateDevice: StateDeviceWidget}
+        if dev_type not in _map:
+            raise NotImplementedError(
+                "No DeviceWidget subclass has been implemented for devices of "
+                f"type {dev_type.name!r}"
+            )
         return _map[dev_type](device_label)
 
 

--- a/micromanager_gui/_gui_objects/_device_widget.py
+++ b/micromanager_gui/_gui_objects/_device_widget.py
@@ -1,0 +1,79 @@
+from typing import Any, Optional, Tuple, TypeVar
+
+from pymmcore_plus import CMMCorePlus, DeviceType
+from qtpy.QtWidgets import QComboBox, QHBoxLayout, QWidget
+
+T = TypeVar("T", bound="DeviceWidget")
+
+
+class DeviceWidget(QWidget):
+    """Base Device Widget.
+
+    Use `DeviceWidget.for_device('someLabel')` to create the device-type
+    appropriate subclass.
+    """
+
+    def __init__(self, device_label: str, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self._device_label = device_label
+        self._mmc = CMMCorePlus.instance()
+
+    def deviceName(self) -> str:
+        return self._mmc.getDeviceName()
+
+    @classmethod
+    def for_device(cls, label: str):
+        core = CMMCorePlus.instance()
+        dt = core.getDeviceType("Objective")
+        _map = {DeviceType.StateDevice: StateWidget}
+        return _map[dt](label)
+
+
+class StateWidget(DeviceWidget):
+    """Widget to control a StateDevice."""
+
+    def __init__(self, device_label: str, parent: Optional[QWidget] = None):
+        super().__init__(device_label, parent)
+        assert self._mmc.getDeviceType(device_label) == DeviceType.StateDevice
+
+        self._combo = QComboBox()
+        self._combo.currentIndexChanged.connect(self._on_combo_changed)
+        self._refresh_combo()
+
+        self.setLayout(QHBoxLayout())
+        self.layout().addWidget(self._combo)
+
+        self._mmc.events.propertyChanged.connect(self._on_prop_change)
+        self.destroyed.connect(self._disconnect)
+
+    def _on_combo_changed(self, index: int) -> None:
+        # TODO: add hook here for pre change/post change
+        # e.g. if you wanted to drop the objective before changing
+        self._mmc.setState(self._device_label, index)
+
+    def _disconnect(self):
+        self._mmc.events.propertyChanged.connect(self._on_prop_change)
+
+    def _on_prop_change(self, dev_label: str, prop: str, value: Any):
+        if dev_label == self._device_label:
+            pre = self._combo.blockSignals(True)
+            self._combo.setCurrentText(value)
+            self._combo.blockSignals(pre)
+
+    def _refresh_combo(self):
+        pre = self._combo.blockSignals(True)
+        self._combo.clear()
+        self._combo.addItems(self.stateLabels())
+        self._combo.blockSignals(pre)
+
+    def state(self) -> int:
+        return self._mmc.getState(self._device_label)
+
+    def data(self):
+        return self._mmc.getData(self._device_label)
+
+    def stateLabel(self) -> str:
+        return self._mmc.getStateLabel(self._device_label)
+
+    def stateLabels(self) -> Tuple[str]:
+        return self._mmc.getStateLabels(self._device_label)

--- a/micromanager_gui/_gui_objects/_device_widget.py
+++ b/micromanager_gui/_gui_objects/_device_widget.py
@@ -25,11 +25,11 @@ class DeviceWidget(QWidget):
     def for_device(cls, label: str):
         core = CMMCorePlus.instance()
         dt = core.getDeviceType("Objective")
-        _map = {DeviceType.StateDevice: StateWidget}
+        _map = {DeviceType.StateDevice: StateDeviceWidget}
         return _map[dt](label)
 
 
-class StateWidget(DeviceWidget):
+class StateDeviceWidget(DeviceWidget):
     """Widget to control a StateDevice."""
 
     def __init__(self, device_label: str, parent: Optional[QWidget] = None):

--- a/micromanager_gui/_gui_objects/_device_widget.py
+++ b/micromanager_gui/_gui_objects/_device_widget.py
@@ -1,4 +1,5 @@
-from typing import Any, Optional, Tuple, TypeVar
+from abc import abstractmethod
+from typing import Any, Optional, Tuple
 
 from pymmcore_plus import DeviceType
 from qtpy.QtWidgets import QComboBox, QHBoxLayout, QWidget
@@ -6,41 +7,88 @@ from superqt.utils import signals_blocked
 
 from .._core import get_core_singleton
 
-T = TypeVar("T", bound="DeviceWidget")
-
 
 class DeviceWidget(QWidget):
     """Base Device Widget.
 
-    Use `DeviceWidget.for_device('someLabel')` to create the device-type
+    Use `DeviceWidget.for_device('someLabel')` to create a device-type
     appropriate subclass.
+
+    Parameters
+    ----------
+    device_label : str
+        A device label for which to create a widget.
+    parent : Optional[QWidget]
+        Optional parent widget.
     """
 
-    def __init__(self, device_label: str, parent: Optional[QWidget] = None):
+    def __init__(self, device_label: str, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         self._device_label = device_label
         self._mmc = get_core_singleton()
+        self.destroyed.connect(self._disconnect)
 
-    def deviceName(self) -> str:
-        return self._mmc.getDeviceName(self._device_label)
+    @abstractmethod
+    def _disconnect():
+        """Disconnect from core when the widget is destroyed.
+
+        Must implement in subclass. (note we can't actually enforce this without
+        subclassing from abc.ABC, but that has an incompatible metaclass with QWidget).
+
+        The goal is that any connections made in init must have a corresponding
+        disconnection that will be called when this widget is destroyed.
+
+        # connect
+        core.events.propertyChanged.connect(self._on_prop_change)
+        # disconnect
+        core.events.propertyChanged.disconnect(self._on_prop_change)
+        """
 
     def deviceLabel(self) -> str:
+        """Return device label."""
         return self._device_label
 
+    def deviceName(self) -> str:
+        """Return device name (this is *not* the device label)."""
+        return self._mmc.getDeviceName(self._device_label)
+
+    def deviceType(self) -> DeviceType:
+        """Return type of Device (`pymmcore_plus.DeviceType`)."""
+        return self._mmc.getDeviceType(self._device_label)
+
     @classmethod
-    def for_device(cls, label: str):
-        core = get_core_singleton()
-        dev_type = core.getDeviceType(label)
+    def for_device(cls, device_label: str) -> "DeviceWidget":
+        """Create a device-type appropriate subclass for device with label `device_label`.
+
+        Parameters
+        ----------
+        label : str
+            A deviceLabel for which to create a widget.
+
+        Returns
+        -------
+        DeviceWidget
+            Appropriate DeviceWidget subclass instance.
+        """
+        dev_type = get_core_singleton().getDeviceType(device_label)
         _map = {DeviceType.StateDevice: StateDeviceWidget}
-        return _map[dev_type](label)
+        return _map[dev_type](device_label)
 
 
 class StateDeviceWidget(DeviceWidget):
-    """Widget to control a StateDevice."""
+    """Widget with a ComboBox to control the states of a StateDevice.
 
-    def __init__(self, device_label: str, parent: Optional[QWidget] = None):
+    Parameters
+    ----------
+    device_label : str
+        A device label for which to create a widget.
+    parent : Optional[QWidget]
+        Optional parent widget.
+    """
+
+    def __init__(self, device_label: str, parent: Optional[QWidget] = None) -> None:
         super().__init__(device_label, parent)
-        assert self._mmc.getDeviceType(device_label) == DeviceType.StateDevice
+        assert self.deviceType() == DeviceType.StateDevice
 
         self._combo = QComboBox()
         self._combo.currentIndexChanged.connect(self._on_combo_changed)
@@ -49,39 +97,36 @@ class StateDeviceWidget(DeviceWidget):
 
         self.setLayout(QHBoxLayout())
         self.layout().addWidget(self._combo)
-
         self._mmc.events.propertyChanged.connect(self._on_prop_change)
-        self.destroyed.connect(self._disconnect)
 
-    def _on_combo_changed(self, index: int) -> None:
-        # TODO: add hook here for pre change/post change?
-        # e.g. if you wanted to drop the objective before changing
-        self._mmc.setState(self._device_label, index)
-
-    def _disconnect(self):
+    def _disconnect(self) -> None:
+        """Disconnect from core when the widget is destroyed."""
         self._mmc.events.propertyChanged.disconnect(self._on_prop_change)
 
-    def _on_prop_change(self, dev_label: str, prop: str, value: Any):
-        # TODO: hmmm... it appears that not all state devices emit
-        # a property change event?
-        print("PROP CHANGE", locals())
-        if dev_label == self._device_label:
+    def _on_combo_changed(self, index: int) -> None:
+        """Update core state when the combobox changes."""
+        self._mmc.setState(self._device_label, index)
+
+    def _on_prop_change(self, dev_label: str, prop: str, value: Any) -> None:
+        """Update the combobox when the state changes."""
+        if dev_label == self._device_label and prop == "Label":
             with signals_blocked(self._combo):
                 self._combo.setCurrentText(value)
 
-    def _refresh_combo_choices(self):
+    def _refresh_combo_choices(self) -> None:
+        """Refresh the combobox choices from core."""
         with signals_blocked(self._combo):
             self._combo.clear()
             self._combo.addItems(self.stateLabels())
 
     def state(self) -> int:
+        """Return current state (index) of the device."""
         return self._mmc.getState(self._device_label)
 
-    def data(self):
-        return self._mmc.getData(self._device_label)
-
     def stateLabel(self) -> str:
+        """Return current state (label) of the device."""
         return self._mmc.getStateLabel(self._device_label)
 
     def stateLabels(self) -> Tuple[str]:
+        """Return all state labels of the device."""
         return self._mmc.getStateLabels(self._device_label)

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     pymmcore-plus >=0.2.1
     useq-schema >=0.1.0
     magicgui >=0.3.0
+    superqt >=0.3.1
 
 [options.extras_require]
 testing =

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ include_package_data = True
 install_requires =
     napari >=0.4.13
     scikit-image
-    pymmcore-plus >=0.2.1
+    pymmcore-plus >=0.3.0
     useq-schema >=0.1.0
     magicgui >=0.3.0
     superqt >=0.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
 
 [options.extras_require]
 testing =
-    pymmcore-plus[remote]
+    pymmcore-plus[remote] >=0.3.0
     pytest
     pytest-qt
     pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
 
 [options.extras_require]
 testing =
+    pymmcore-plus[remote]
     pytest
     pytest-qt
     pytest-cov

--- a/tests/test_device_widget.py
+++ b/tests/test_device_widget.py
@@ -1,34 +1,32 @@
-from pymmcore_plus import CMMCorePlus
+from pymmcore_plus import CMMCorePlus, DeviceType
 
 from micromanager_gui._gui_objects._device_widget import DeviceWidget, StateDeviceWidget
 
 
 def test_state_device_widget(qtbot, global_mmcore: CMMCorePlus):
-    # FIXME? not sure if possible, but this test won't work for devices that
-    # don't broadcast their change with an event from core.
-    # for label in global_mmcore.getLoadedDevicesOfType(DeviceType.StateDevice):
-    # so, for now, just test objective
-    label = "Objective"
+    for label in global_mmcore.getLoadedDevicesOfType(DeviceType.StateDevice):
+        wdg: StateDeviceWidget = DeviceWidget.for_device(label)
+        qtbot.addWidget(wdg)
+        wdg.show()
+        assert wdg.deviceLabel() == label
+        # assert wdg.deviceName() == "DObjective"
+        assert global_mmcore.getStateLabel(label) == wdg._combo.currentText()
+        assert global_mmcore.getState(label) == wdg._combo.currentIndex()
+        start_state = wdg.state()
 
-    wdg: StateDeviceWidget = DeviceWidget.for_device(label)
-    qtbot.addWidget(wdg)
-    wdg.show()
-    assert wdg.deviceLabel() == label
-    assert wdg.deviceName() == "DObjective"
-    assert global_mmcore.getStateLabel(label) == wdg._combo.currentText()
-    assert global_mmcore.getState(label) == wdg._combo.currentIndex()
-    start_state = wdg.state()
+        next_state = (wdg.state() + 1) % len(wdg.stateLabels())
+        with qtbot.waitSignal(global_mmcore.events.propertyChanged):
+            global_mmcore.setState(label, next_state)
 
-    next_state = (wdg.state() + 1) % len(wdg.stateLabels())
-    with qtbot.waitSignal(global_mmcore.events.propertyChanged):
-        global_mmcore.setState(label, next_state)
+        assert wdg.state() != start_state
+        assert wdg.state() == global_mmcore.getState(label) == wdg._combo.currentIndex()
+        assert (
+            wdg.stateLabel()
+            == global_mmcore.getStateLabel(label)
+            == wdg._combo.currentText()
+        )
 
-    assert wdg.state() != start_state
-    assert wdg.state() == global_mmcore.getState(label) == wdg._combo.currentIndex()
-    assert (
-        wdg.stateLabel()
-        == global_mmcore.getStateLabel(label)
-        == wdg._combo.currentText()
-    )
-
-    wdg._disconnect()
+        wdg._disconnect()
+        # once disconnected, core changes shouldn't call out to the widget
+        global_mmcore.setState(label, start_state)
+        assert global_mmcore.getStateLabel(label) != wdg._combo.currentText()

--- a/tests/test_device_widget.py
+++ b/tests/test_device_widget.py
@@ -14,6 +14,7 @@ def test_state_device_widget(qtbot, global_mmcore: CMMCorePlus):
     qtbot.addWidget(wdg)
     wdg.show()
     assert wdg.deviceLabel() == label
+    assert wdg.deviceName() == "DObjective"
     assert global_mmcore.getStateLabel(label) == wdg._combo.currentText()
     assert global_mmcore.getState(label) == wdg._combo.currentIndex()
     start_state = wdg.state()
@@ -23,5 +24,12 @@ def test_state_device_widget(qtbot, global_mmcore: CMMCorePlus):
         global_mmcore.setState(label, next_state)
 
     assert wdg.state() != start_state
-    assert global_mmcore.getState(label) == wdg._combo.currentIndex()
-    assert global_mmcore.getStateLabel(label) == wdg._combo.currentText()
+    assert wdg.data()
+    assert wdg.state() == global_mmcore.getState(label) == wdg._combo.currentIndex()
+    assert (
+        wdg.stateLabel()
+        == global_mmcore.getStateLabel(label)
+        == wdg._combo.currentText()
+    )
+
+    wdg._disconnect()

--- a/tests/test_device_widget.py
+++ b/tests/test_device_widget.py
@@ -1,0 +1,27 @@
+from pymmcore_plus import CMMCorePlus
+
+from micromanager_gui._gui_objects._device_widget import DeviceWidget, StateDeviceWidget
+
+
+def test_state_device_widget(qtbot, global_mmcore: CMMCorePlus):
+    # FIXME? not sure if possible, but this test won't work for devices that
+    # don't broadcast their change with an event from core.
+    # for label in global_mmcore.getLoadedDevicesOfType(DeviceType.StateDevice):
+    # so, for now, just test objective
+    label = "Objective"
+
+    wdg: StateDeviceWidget = DeviceWidget.for_device(label)
+    qtbot.addWidget(wdg)
+    wdg.show()
+    assert wdg.deviceLabel() == label
+    assert global_mmcore.getStateLabel(label) == wdg._combo.currentText()
+    assert global_mmcore.getState(label) == wdg._combo.currentIndex()
+    start_state = wdg.state()
+
+    next_state = (wdg.state() + 1) % len(wdg.stateLabels())
+    with qtbot.waitSignal(global_mmcore.events.propertyChanged):
+        global_mmcore.setState(label, next_state)
+
+    assert wdg.state() != start_state
+    assert global_mmcore.getState(label) == wdg._combo.currentIndex()
+    assert global_mmcore.getStateLabel(label) == wdg._combo.currentText()

--- a/tests/test_device_widget.py
+++ b/tests/test_device_widget.py
@@ -24,7 +24,6 @@ def test_state_device_widget(qtbot, global_mmcore: CMMCorePlus):
         global_mmcore.setState(label, next_state)
 
     assert wdg.state() != start_state
-    assert wdg.data()
     assert wdg.state() == global_mmcore.getState(label) == wdg._combo.currentIndex()
     assert (
         wdg.stateLabel()


### PR DESCRIPTION
a start on creating more generic widgets that work for given device types.

This establishes new base class `DeviceWidget` that accepts the name of a device and is expected to make widget that controls the device.  In most cases, it will be created with the classmethod `DeviceWidget.for_device('deviceLabel')` which creates the appropriate subclass.  Here, `StateDevice` is implemented... but `for_device` will raise a NotImplementedError for all other device types (to be implemented later).

