### PR TITLE
Begin cleanup and decoupling of mda

### DIFF
--- a/launch-dev.py
+++ b/launch-dev.py
@@ -18,5 +18,8 @@ sequence = MDASequence(
 )
 
 main_window.mda.set_state(sequence)
+v.window._qt_viewer.console.push(
+    {"main_window": main_window, "mmc": core, "sequence": sequence}
+)
 
 napari.run()

--- a/launch-dev.py
+++ b/launch-dev.py
@@ -18,6 +18,17 @@ sequence = MDASequence(
 )
 
 main_window.mda.set_state(sequence)
+
+# manually set state of explorer
+explorer = main_window.explorer
+explorer.scan_size_spinBox_r.setValue(2)
+explorer.scan_size_spinBox_c.setValue(2)
+explorer.add_ch_explorer_Button.click()
+explorer.channel_explorer_comboBox.setCurrentText("Cy5")
+explorer.add_ch_explorer_Button.click()
+explorer.channel_explorer_comboBox.setCurrentText("FITC")
+
+# fill napari-console with useful variables
 v.window._qt_viewer.console.push(
     {"main_window": main_window, "mmc": core, "sequence": sequence}
 )

--- a/micromanager_gui/_gui_objects/_mda_widget.py
+++ b/micromanager_gui/_gui_objects/_mda_widget.py
@@ -1,32 +1,22 @@
 from __future__ import annotations
 
 import warnings
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pymmcore_plus import CMMCorePlus
 from qtpy import QtWidgets as QtW
 from qtpy import uic
 from qtpy.QtCore import QSize, Qt
 from qtpy.QtGui import QIcon
-from typing_extensions import Literal
 from useq import MDASequence
+
+from .._core import get_core_singleton
+from .._mda import SEQUENCE_META, SequenceMeta
 
 if TYPE_CHECKING:
     from pymmcore_plus.mda import PMDAEngine
 
 ICONS = Path(__file__).parent.parent / "icons"
-
-
-@dataclass
-class SequenceMeta:
-    mode: Literal["mda"] | Literal["explorer"] = ""
-    split_channels: bool = False
-    should_save: bool = False
-    file_name: str = ""
-    save_dir: str = ""
-    save_pos: bool = False
 
 
 class _MultiDUI:
@@ -90,15 +80,11 @@ class _MultiDUI:
 
 
 class MultiDWidget(QtW.QWidget, _MultiDUI):
-
-    # metadata associated with a given experiment
-    SEQUENCE_META: dict[MDASequence, SequenceMeta] = {}
-
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setup_ui()
 
-        self._mmc = CMMCorePlus.instance()
+        self._mmc = get_core_singleton()
 
         self.pause_Button.released.connect(lambda: self._mmc.mda.toggle_pause())
         self.cancel_Button.released.connect(lambda: self._mmc.mda.cancel())
@@ -504,7 +490,7 @@ class MultiDWidget(QtW.QWidget, _MultiDUI):
 
         experiment = self.get_state()
 
-        self.SEQUENCE_META[experiment] = SequenceMeta(
+        SEQUENCE_META[experiment] = SequenceMeta(
             mode="mda",
             split_channels=self.checkBox_split_channels.isChecked(),
             should_save=self.save_groupBox.isChecked(),

--- a/micromanager_gui/_gui_objects/_mm_widget.py
+++ b/micromanager_gui/_gui_objects/_mm_widget.py
@@ -9,6 +9,7 @@ from ._config_widget import MMConfigurationWidget
 from ._mda_widget import MultiDWidget
 from ._objective_widget import MMObjectivesWidget
 from ._property_browser_widget import MMPropertyBrowserWidget
+from ._sample_explorer_widget import ExploreSample
 from ._shutters_widget import MMShuttersWidget
 from ._slider_dialog import SliderDialog
 from ._tab_widget import MMTabWidget
@@ -30,6 +31,7 @@ class MicroManagerWidget(QtW.QWidget):
         self.prop_wdg = MMPropertyBrowserWidget()
         self.shutter_wdg = MMShuttersWidget()
         self.mda = MultiDWidget()
+        self.explorer = ExploreSample()
 
         self.create_gui()
 
@@ -82,6 +84,7 @@ class MicroManagerWidget(QtW.QWidget):
         self.main_layout.addWidget(self.stages_group)
 
         self.tab_wdg.tabWidget.addTab(self.mda, "Multi-D Acquisition")
+        self.tab_wdg.tabWidget.addTab(self.explorer, "Sample Explorer")
 
         # add tab widget
         self.main_layout.addWidget(self.tab_wdg)

--- a/micromanager_gui/_gui_objects/_mm_widget.py
+++ b/micromanager_gui/_gui_objects/_mm_widget.py
@@ -6,6 +6,7 @@ from superqt import QCollapsible
 
 from ._camera_widget import MMCameraWidget
 from ._config_widget import MMConfigurationWidget
+from ._mda_widget import MultiDWidget
 from ._objective_widget import MMObjectivesWidget
 from ._property_browser_widget import MMPropertyBrowserWidget
 from ._shutters_widget import MMShuttersWidget
@@ -28,6 +29,7 @@ class MicroManagerWidget(QtW.QWidget):
         self.tab_wdg = MMTabWidget()
         self.prop_wdg = MMPropertyBrowserWidget()
         self.shutter_wdg = MMShuttersWidget()
+        self.mda = MultiDWidget()
 
         self.create_gui()
 
@@ -78,6 +80,8 @@ class MicroManagerWidget(QtW.QWidget):
         self.stages_group_layout.addWidget(self.stages_coll)
         self.stages_group.setLayout(self.stages_group_layout)
         self.main_layout.addWidget(self.stages_group)
+
+        self.tab_wdg.tabWidget.addTab(self.mda, "Multi-D Acquisition")
 
         # add tab widget
         self.main_layout.addWidget(self.tab_wdg)

--- a/micromanager_gui/_gui_objects/_sample_explorer_widget.py
+++ b/micromanager_gui/_gui_objects/_sample_explorer_widget.py
@@ -13,9 +13,6 @@ from .. import _mda
 from .._core import get_core_singleton
 
 if TYPE_CHECKING:
-    pass
-
-if TYPE_CHECKING:
     from pymmcore_plus.mda import PMDAEngine
 
 

--- a/micromanager_gui/_mda.py
+++ b/micromanager_gui/_mda.py
@@ -1,0 +1,26 @@
+"""metadata class and shared state for managing MDAs"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Union
+
+from typing_extensions import Literal
+from useq import MDASequence
+
+__all__ = [
+    "SequenceMeta",
+    "SEQUENCE_META",
+]
+
+
+@dataclass
+class SequenceMeta:
+    mode: Union[Literal["mda"], Literal["explorer"]] = ""
+    split_channels: bool = False
+    should_save: bool = False
+    file_name: str = ""
+    save_dir: str = ""
+    save_pos: bool = False
+
+
+SEQUENCE_META: dict[MDASequence, SequenceMeta] = {}

--- a/micromanager_gui/_saving.py
+++ b/micromanager_gui/_saving.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from napari.components import LayerList
     from useq import MDASequence
 
-    from .multid_widget import SequenceMeta
+    from ._gui_objects._mda_widget import SequenceMeta
 
 
 def _imsave(file: Path, data: np.ndarray, dtype="uint16"):

--- a/micromanager_gui/explore_sample.py
+++ b/micromanager_gui/explore_sample.py
@@ -13,7 +13,9 @@ from qtpy import uic
 from useq import MDASequence
 
 from ._saving import save_sequence
-from .multid_widget import SequenceMeta
+
+if TYPE_CHECKING:
+    from ._gui_objects._mda_widget import SequenceMeta
 
 if TYPE_CHECKING:
     import napari.viewer
@@ -128,6 +130,8 @@ class ExploreSample(QtW.QWidget):
 
     def _on_explorer_frame(self, image: np.ndarray, event: useq.MDAEvent):
         seq = event.sequence
+        from ._gui_objects._mda_widget import SequenceMeta
+
         meta = self.SEQUENCE_META.get(event.sequence) or SequenceMeta()
         if meta.mode != "explorer":
             return
@@ -162,6 +166,8 @@ class ExploreSample(QtW.QWidget):
         self.viewer.reset_view()
 
     def _on_mda_finished(self, sequence: useq.MDASequence):
+        from ._gui_objects._mda_widget import SequenceMeta
+
         meta = self.SEQUENCE_META.get(sequence) or SequenceMeta()
         seq_uid = sequence.uid
 

--- a/micromanager_gui/explore_sample.py
+++ b/micromanager_gui/explore_sample.py
@@ -12,10 +12,11 @@ from qtpy import QtWidgets as QtW
 from qtpy import uic
 from useq import MDASequence
 
+from . import _mda
 from ._saving import save_sequence
 
 if TYPE_CHECKING:
-    from ._gui_objects._mda_widget import SequenceMeta
+    pass
 
 if TYPE_CHECKING:
     import napari.viewer
@@ -52,9 +53,6 @@ class ExploreSample(QtW.QWidget):
     x_lineEdit: QtW.QLineEdit
     y_lineEdit: QtW.QLineEdit
     ovelap_spinBox: QtW.QSpinBox
-
-    # metadata associated with a given experiment
-    SEQUENCE_META: dict[MDASequence, SequenceMeta] = {}
 
     def __init__(self, viewer: napari.viewer.Viewer, mmcore: RemoteMMCore, parent=None):
 
@@ -130,9 +128,8 @@ class ExploreSample(QtW.QWidget):
 
     def _on_explorer_frame(self, image: np.ndarray, event: useq.MDAEvent):
         seq = event.sequence
-        from ._gui_objects._mda_widget import SequenceMeta
 
-        meta = self.SEQUENCE_META.get(event.sequence) or SequenceMeta()
+        meta = _mda.SEQUENCE_META.get(seq) or _mda.SequenceMeta()
         if meta.mode != "explorer":
             return
 
@@ -166,9 +163,7 @@ class ExploreSample(QtW.QWidget):
         self.viewer.reset_view()
 
     def _on_mda_finished(self, sequence: useq.MDASequence):
-        from ._gui_objects._mda_widget import SequenceMeta
-
-        meta = self.SEQUENCE_META.get(sequence) or SequenceMeta()
+        meta = _mda.SEQUENCE_META.get(sequence) or _mda.SequenceMeta()
         seq_uid = sequence.uid
 
         if meta.mode == "explorer":
@@ -190,7 +185,7 @@ class ExploreSample(QtW.QWidget):
             for group in layergroups.values():
                 link_layers(group)
 
-        meta = self.SEQUENCE_META.pop(sequence, SequenceMeta())
+        meta = _mda.SEQUENCE_META.pop(sequence, _mda.SequenceMeta())
         save_sequence(sequence, self.viewer.layers, meta)
         self._set_enabled(True)
 
@@ -370,7 +365,7 @@ class ExploreSample(QtW.QWidget):
 
         explore_sample = MDASequence(**self._get_state_dict())
 
-        self.SEQUENCE_META[explore_sample] = SequenceMeta(
+        _mda.SEQUENCE_META[explore_sample] = _mda.SequenceMeta(
             mode="explorer",
             split_channels=True,
             should_save=self.save_explorer_groupBox.isChecked(),

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import napari
 import numpy as np
+from napari.experimental import link_layers
 from pymmcore_plus import DeviceType
 from pymmcore_plus._util import find_micromanager
 from qtpy import QtWidgets as QtW
@@ -22,7 +24,6 @@ from ._util import (
     event_indices,
     extend_array_for_index,
 )
-from .explore_sample import ExploreSample
 from .prop_browser import PropBrowser
 
 if TYPE_CHECKING:
@@ -54,10 +55,7 @@ class MainWindow(MicroManagerWidget):
                 "MICROMANAGER_PATH."
             )
 
-        self.explorer = ExploreSample(self.viewer, self._mmc)
-
         # add mda and explorer tabs to mm_tab widget
-        self.tab_wdg.tabWidget.addTab(self.explorer, "Sample Explorer")
         sizepolicy = QtW.QSizePolicy(
             QtW.QSizePolicy.Expanding, QtW.QSizePolicy.Expanding
         )
@@ -122,6 +120,27 @@ class MainWindow(MicroManagerWidget):
         self.viewer.layers.events.connect(self.update_max_min)
         self.viewer.layers.selection.events.active.connect(self.update_max_min)
         self.viewer.dims.events.current_step.connect(self.update_max_min)
+
+        @self.viewer.mouse_drag_callbacks.append
+        def get_event(viewer, event):
+            if not self.explorer.isVisible():
+                return
+            if self._mmc.getPixelSizeUm() > 0:
+                width = self._mmc.getROI(self._mmc.getCameraDevice())[2]
+                height = self._mmc.getROI(self._mmc.getCameraDevice())[3]
+
+                x = viewer.cursor.position[-1] * self._mmc.getPixelSizeUm()
+                y = viewer.cursor.position[-2] * self._mmc.getPixelSizeUm() * (-1)
+
+                # to match position coordinates with center of the image
+                x = f"{x - ((width / 2) * self._mmc.getPixelSizeUm()):.1f}"
+                y = f"{y - ((height / 2) * self._mmc.getPixelSizeUm() * (-1)):.1f}"
+
+            else:
+                x, y = "None", "None"
+
+            self.x_lineEdit.setText(x)
+            self.y_lineEdit.setText(y)
 
     def _on_system_cfg_loaded(self):
         if len(self._mmc.getLoadedDevices()) > 1:
@@ -269,55 +288,109 @@ class MainWindow(MicroManagerWidget):
     def _on_mda_frame(self, image: np.ndarray, event: useq.MDAEvent):
 
         meta = self._mda_meta
-        if meta.mode != "mda":
-            return
+        if meta.mode == "mda":
 
-        # pick layer name
-        file_name = meta.file_name if meta.should_save else "Exp"
-        channelstr = (
-            f"[{event.channel.config}_idx{event.index['c']}]_"
-            if meta.split_channels
-            else ""
-        )
-        layer_name = f"{file_name}_{channelstr}{event.sequence.uid}"
+            # pick layer name
+            file_name = meta.file_name if meta.should_save else "Exp"
+            channelstr = (
+                f"[{event.channel.config}_idx{event.index['c']}]_"
+                if meta.split_channels
+                else ""
+            )
+            layer_name = f"{file_name}_{channelstr}{event.sequence.uid}"
 
-        try:  # see if we already have a layer with this sequence
-            layer = self.viewer.layers[layer_name]
+            try:  # see if we already have a layer with this sequence
+                layer = self.viewer.layers[layer_name]
 
-            # get indices of new image
-            im_idx = tuple(
-                event.index[k]
-                for k in event_indices(event)
-                if not (meta.split_channels and k == "c")
+                # get indices of new image
+                im_idx = tuple(
+                    event.index[k]
+                    for k in event_indices(event)
+                    if not (meta.split_channels and k == "c")
+                )
+
+                # make sure array shape contains im_idx, or pad with zeros
+                new_array = extend_array_for_index(layer.data, im_idx)
+                # add the incoming index at the appropriate index
+                new_array[im_idx] = image
+                # set layer data
+                layer.data = new_array
+                for a, v in enumerate(im_idx):
+                    self.viewer.dims.set_point(a, v)
+
+            except KeyError:  # add the new layer to the viewer
+                seq = event.sequence
+                _image = image[(np.newaxis,) * len(seq.shape)]
+                layer = self.viewer.add_image(
+                    _image, name=layer_name, blending="additive"
+                )
+
+                # dimensions labels
+                labels = [i for i in seq.axis_order if i in event.index] + ["y", "x"]
+                self.viewer.dims.axis_labels = labels
+
+                # add metadata to layer
+                layer.metadata["useq_sequence"] = seq
+                layer.metadata["uid"] = seq.uid
+                # storing event.index in addition to channel.config because it's
+                # possible to have two of the same channel in one sequence.
+                layer.metadata[
+                    "ch_id"
+                ] = f'{event.channel.config}_idx{event.index["c"]}'
+        elif meta.mode == "explorer":
+
+            seq = event.sequence
+
+            meta = _mda.SEQUENCE_META.get(seq) or _mda.SequenceMeta()
+            if meta.mode != "explorer":
+                return
+
+            x = event.x_pos / self.explorer.pixel_size
+            y = event.y_pos / self.explorer.pixel_size * (-1)
+
+            pos_idx = event.index["p"]
+            file_name = meta.file_name if meta.should_save else "Exp"
+            ch_name = event.channel.config
+            ch_id = event.index["c"]
+            layer_name = f"Pos{pos_idx:03d}_{file_name}_{ch_name}_idx{ch_id}"
+
+            meta = dict(
+                useq_sequence=seq,
+                uid=seq.uid,
+                scan_coord=(y, x),
+                scan_position=f"Pos{pos_idx:03d}",
+                ch_name=ch_name,
+                ch_id=ch_id,
+            )
+            self.viewer.add_image(
+                image,
+                name=layer_name,
+                blending="additive",
+                translate=(y, x),
+                metadata=meta,
             )
 
-            # make sure array shape contains im_idx, or pad with zeros
-            new_array = extend_array_for_index(layer.data, im_idx)
-            # add the incoming index at the appropriate index
-            new_array[im_idx] = image
-            # set layer data
-            layer.data = new_array
-            for a, v in enumerate(im_idx):
-                self.viewer.dims.set_point(a, v)
-
-        except KeyError:  # add the new layer to the viewer
-            seq = event.sequence
-            _image = image[(np.newaxis,) * len(seq.shape)]
-            layer = self.viewer.add_image(_image, name=layer_name, blending="additive")
-
-            # dimensions labels
-            labels = [i for i in seq.axis_order if i in event.index] + ["y", "x"]
-            self.viewer.dims.axis_labels = labels
-
-            # add metadata to layer
-            layer.metadata["useq_sequence"] = seq
-            layer.metadata["uid"] = seq.uid
-            # storing event.index in addition to channel.config because it's
-            # possible to have two of the same channel in one sequence.
-            layer.metadata["ch_id"] = f'{event.channel.config}_idx{event.index["c"]}'
+            zoom_out_factor = (
+                self.explorer.scan_size_r
+                if self.explorer.scan_size_r >= self.explorer.scan_size_c
+                else self.explorer.scan_size_c
+            )
+            self.viewer.camera.zoom = 1 / zoom_out_factor
+            self.viewer.reset_view()
 
     def _on_mda_finished(self, sequence: useq.MDASequence):
         """Save layer and add increment to save name."""
+        meta = _mda.SEQUENCE_META.get(sequence) or _mda.SequenceMeta()
+        seq_uid = sequence.uid
+        if meta.mode == "explorer":
+
+            layergroups = defaultdict(set)
+            for lay in self.viewer.layers:
+                if lay.metadata.get("uid") == seq_uid:
+                    key = f"{lay.metadata['ch_name']}_idx{lay.metadata['ch_id']}"
+                    layergroups[key].add(lay)
+            for group in layergroups.values():
+                link_layers(group)
         meta = _mda.SEQUENCE_META.pop(sequence, self._mda_meta)
         save_sequence(sequence, self.viewer.layers, meta)
         # reactivate gui when mda finishes.

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -12,9 +12,8 @@ from qtpy.QtCore import QTimer
 from qtpy.QtGui import QColor, QIcon
 from superqt.utils import create_worker, ensure_main_thread
 
-from . import _core
+from . import _core, _mda
 from ._camera_roi import CameraROI
-from ._gui_objects._mda_widget import SequenceMeta
 from ._gui_objects._mm_widget import MicroManagerWidget
 from ._saving import save_sequence
 from ._util import (
@@ -261,7 +260,7 @@ class MainWindow(MicroManagerWidget):
         """ "create temp folder and block gui when mda starts."""
         self._set_enabled(False)
 
-        self._mda_meta = self.mda.SEQUENCE_META.get(sequence, SequenceMeta())
+        self._mda_meta = _mda.SEQUENCE_META.get(sequence, _mda.SequenceMeta())
         if self._mda_meta.mode == "":
             # originated from user script - assume it's an mda
             self._mda_meta.mode = "mda"
@@ -319,7 +318,7 @@ class MainWindow(MicroManagerWidget):
 
     def _on_mda_finished(self, sequence: useq.MDASequence):
         """Save layer and add increment to save name."""
-        meta = self.mda.SEQUENCE_META.pop(sequence, self._mda_meta)
+        meta = _mda.SEQUENCE_META.pop(sequence, self._mda_meta)
         save_sequence(sequence, self.viewer.layers, meta)
         # reactivate gui when mda finishes.
         self._set_enabled(True)

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -121,26 +121,7 @@ class MainWindow(MicroManagerWidget):
         self.viewer.layers.selection.events.active.connect(self.update_max_min)
         self.viewer.dims.events.current_step.connect(self.update_max_min)
 
-        @self.viewer.mouse_drag_callbacks.append
-        def get_event(viewer, event):
-            if not self.explorer.isVisible():
-                return
-            if self._mmc.getPixelSizeUm() > 0:
-                width = self._mmc.getROI(self._mmc.getCameraDevice())[2]
-                height = self._mmc.getROI(self._mmc.getCameraDevice())[3]
-
-                x = viewer.cursor.position[-1] * self._mmc.getPixelSizeUm()
-                y = viewer.cursor.position[-2] * self._mmc.getPixelSizeUm() * (-1)
-
-                # to match position coordinates with center of the image
-                x = f"{x - ((width / 2) * self._mmc.getPixelSizeUm()):.1f}"
-                y = f"{y - ((height / 2) * self._mmc.getPixelSizeUm() * (-1)):.1f}"
-
-            else:
-                x, y = "None", "None"
-
-            self.explorer.x_lineEdit.setText(x)
-            self.explorer.y_lineEdit.setText(y)
+        self.viewer.mouse_drag_callbacks.append(self._get_event_explorer)
 
     def _on_system_cfg_loaded(self):
         if len(self._mmc.getLoadedDevices()) > 1:
@@ -395,6 +376,26 @@ class MainWindow(MicroManagerWidget):
         save_sequence(sequence, self.viewer.layers, meta)
         # reactivate gui when mda finishes.
         self._set_enabled(True)
+
+    def _get_event_explorer(self, viewer, event):
+        if not self.explorer.isVisible():
+            return
+        if self._mmc.getPixelSizeUm() > 0:
+            width = self._mmc.getROI(self._mmc.getCameraDevice())[2]
+            height = self._mmc.getROI(self._mmc.getCameraDevice())[3]
+
+            x = viewer.cursor.position[-1] * self._mmc.getPixelSizeUm()
+            y = viewer.cursor.position[-2] * self._mmc.getPixelSizeUm() * (-1)
+
+            # to match position coordinates with center of the image
+            x = f"{x - ((width / 2) * self._mmc.getPixelSizeUm()):.1f}"
+            y = f"{y - ((height / 2) * self._mmc.getPixelSizeUm() * (-1)):.1f}"
+
+        else:
+            x, y = "None", "None"
+
+        self.explorer.x_lineEdit.setText(x)
+        self.explorer.y_lineEdit.setText(y)
 
     # exposure time
     def _update_exp(self, exposure: float):

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -14,6 +14,7 @@ from superqt.utils import create_worker, ensure_main_thread
 
 from . import _core
 from ._camera_roi import CameraROI
+from ._gui_objects._mda_widget import SequenceMeta
 from ._gui_objects._mm_widget import MicroManagerWidget
 from ._saving import save_sequence
 from ._util import (
@@ -23,7 +24,6 @@ from ._util import (
     extend_array_for_index,
 )
 from .explore_sample import ExploreSample
-from .multid_widget import MultiDWidget, SequenceMeta
 from .prop_browser import PropBrowser
 
 if TYPE_CHECKING:
@@ -55,12 +55,9 @@ class MainWindow(MicroManagerWidget):
                 "MICROMANAGER_PATH."
             )
 
-        # tab widgets
-        self.mda = MultiDWidget(self._mmc)
         self.explorer = ExploreSample(self.viewer, self._mmc)
 
         # add mda and explorer tabs to mm_tab widget
-        self.tab_wdg.tabWidget.addTab(self.mda, "Multi-D Acquisition")
         self.tab_wdg.tabWidget.addTab(self.explorer, "Sample Explorer")
         sizepolicy = QtW.QSizePolicy(
             QtW.QSizePolicy.Expanding, QtW.QSizePolicy.Expanding

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -139,8 +139,8 @@ class MainWindow(MicroManagerWidget):
             else:
                 x, y = "None", "None"
 
-            self.x_lineEdit.setText(x)
-            self.y_lineEdit.setText(y)
+            self.explorer.x_lineEdit.setText(x)
+            self.explorer.y_lineEdit.setText(y)
 
     def _on_system_cfg_loaded(self):
         if len(self._mmc.getLoadedDevices()) > 1:

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -261,10 +261,15 @@ class MainWindow(MicroManagerWidget):
         """ "create temp folder and block gui when mda starts."""
         self._set_enabled(False)
 
+        self._mda_meta = self.mda.SEQUENCE_META.get(sequence, SequenceMeta())
+        if self._mda_meta.mode == "":
+            # originated from user script - assume it's an mda
+            self._mda_meta.mode = "mda"
+
     @ensure_main_thread
     def _on_mda_frame(self, image: np.ndarray, event: useq.MDAEvent):
-        meta = self.mda.SEQUENCE_META.get(event.sequence) or SequenceMeta()
 
+        meta = self._mda_meta
         if meta.mode != "mda":
             return
 
@@ -314,7 +319,7 @@ class MainWindow(MicroManagerWidget):
 
     def _on_mda_finished(self, sequence: useq.MDASequence):
         """Save layer and add increment to save name."""
-        meta = self.mda.SEQUENCE_META.pop(sequence, SequenceMeta())
+        meta = self.mda.SEQUENCE_META.pop(sequence, self._mda_meta)
         save_sequence(sequence, self.viewer.layers, meta)
         # reactivate gui when mda finishes.
         self._set_enabled(True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,8 @@ from pymmcore_plus import CMMCorePlus
 from useq import MDASequence
 
 from micromanager_gui import _core
+from micromanager_gui._gui_objects._mda_widget import SequenceMeta
 from micromanager_gui.main_window import MainWindow
-from micromanager_gui.multid_widget import SequenceMeta
 
 ExplorerTuple = Tuple[MainWindow, MDASequence, SequenceMeta]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,14 @@
-import uuid
 from pathlib import Path
 from typing import Tuple
 
-import numpy as np
 import pytest
 from pymmcore_plus import CMMCorePlus
 from useq import MDASequence
 
-from micromanager_gui import _core
-from micromanager_gui._gui_objects._mda_widget import SequenceMeta
+from micromanager_gui import _core, _mda
 from micromanager_gui.main_window import MainWindow
 
-ExplorerTuple = Tuple[MainWindow, MDASequence, SequenceMeta]
+ExplorerTuple = Tuple[MainWindow, MDASequence, _mda.SequenceMeta]
 
 
 @pytest.fixture(params=["local"])
@@ -39,71 +36,27 @@ def main_window(global_mmcore, make_napari_viewer):
 
 
 @pytest.fixture
-def explorer_no_channel(main_window: MainWindow) -> ExplorerTuple:
+def explorer_one_channel(main_window: MainWindow) -> ExplorerTuple:
 
-    main_window.explorer.scan_size_spinBox_r.setValue(2)
-    main_window.explorer.scan_size_spinBox_c.setValue(2)
-    main_window.explorer.ovelap_spinBox.setValue(0)
+    explorer = main_window.explorer
+    explorer.scan_size_spinBox_r.setValue(2)
+    explorer.scan_size_spinBox_c.setValue(2)
+    explorer.ovelap_spinBox.setValue(0)
+    explorer.add_ch_explorer_Button.click()
 
-    sequence = MDASequence(
-        channels=["FITC"],
-        stage_positions=[
-            {"x": -256.0, "y": 256.0, "z": 0.0},
-            {"x": 256.0, "y": 256.0, "z": 0.0},
-            {"x": 256.0, "y": -256.0, "z": 0.0},
-            {"x": -256.0, "y": -256.0, "z": 0.0},
-        ],
-        uid=uuid.uuid4(),
-    )
-
-    main_window.explorer.SEQUENCE_META[sequence] = SequenceMeta(
-        mode="explorer",
-        split_channels=True,
-        should_save=False,
-        file_name="EXPLORER",
-        save_dir="",
-    )
-    meta = main_window.explorer.SEQUENCE_META[sequence]
-
-    return main_window, sequence, meta
+    return main_window, explorer
 
 
 @pytest.fixture
-def explorer_one_channel(explorer_no_channel: ExplorerTuple) -> ExplorerTuple:
+def explorer_two_channel(main_window: MainWindow) -> ExplorerTuple:
 
-    main_win, sequence, _ = explorer_no_channel
+    explorer = main_window.explorer
+    explorer.scan_size_spinBox_r.setValue(2)
+    explorer.scan_size_spinBox_c.setValue(2)
+    explorer.ovelap_spinBox.setValue(0)
+    explorer.add_ch_explorer_Button.click()
+    explorer.channel_explorer_comboBox.setCurrentText("Cy5")
+    explorer.add_ch_explorer_Button.click()
+    explorer.channel_explorer_comboBox.setCurrentText("FITC")
 
-    for i in range(4):
-        layer = main_win.viewer.add_image(
-            np.random.rand(10, 10), name=f"Pos{i}_[FITC_idx0]"
-        )
-        layer.metadata["uid"] = sequence.uid
-        layer.metadata["ch_name"] = "FITC"
-        layer.metadata["ch_id"] = 0
-
-    return explorer_no_channel
-
-
-@pytest.fixture
-def explorer_two_channel(explorer_no_channel: ExplorerTuple) -> ExplorerTuple:
-
-    main_win, sequence, _ = explorer_no_channel
-
-    for i in range(4):
-        layer_1 = main_win.viewer.add_image(
-            np.random.rand(10, 10), name=f"Pos{i:03}_[FITC_idx0]"
-        )
-        layer_1.metadata["uid"] = sequence.uid
-        layer_1.metadata["ch_name"] = "FITC"
-        layer_1.metadata["ch_id"] = 0
-        layer_1.metadata["scan_position"] = f"Pos{i:03}"
-
-        layer_2 = main_win.viewer.add_image(
-            np.random.rand(10, 10), name=f"Pos{i:03}_[Cy5_idx0]"
-        )
-        layer_2.metadata["uid"] = sequence.uid
-        layer_2.metadata["ch_name"] = "Cy5"
-        layer_2.metadata["ch_id"] = 1
-        layer_2.metadata["scan_position"] = f"Pos{i:03}"
-
-    return explorer_no_channel
+    return main_window, explorer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,12 @@ from typing import Tuple
 
 import pytest
 from pymmcore_plus import CMMCorePlus
-from useq import MDASequence
 
-from micromanager_gui import _core, _mda
+from micromanager_gui import _core
+from micromanager_gui._gui_objects._sample_explorer_widget import ExploreSample
 from micromanager_gui.main_window import MainWindow
 
-ExplorerTuple = Tuple[MainWindow, MDASequence, _mda.SequenceMeta]
+ExplorerTuple = Tuple[MainWindow, ExploreSample]
 
 
 @pytest.fixture(params=["local"])

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -106,15 +106,14 @@ def test_saving_mda(qtbot: "QtBot", main_window: MainWindow, T, C, splitC, Z):
 def test_script_initiated_mda(main_window: MainWindow, qtbot: "QtBot"):
     # we should show the mda even if it came from outside
     mmc = main_window._mmc
-    print(mmc.getLoadedDevices())
     sequence = MDASequence(
-        channels=[{"config": "Cy5", "exposure": 3}, {"config": "FITC", "exposure": 5}],
+        channels=[{"config": "Cy5", "exposure": 1}, {"config": "FITC", "exposure": 1}],
         time_plan={"interval": 0.1, "loops": 2},
-        z_plan={"range": 4, "step": 0.5},
+        z_plan={"range": 4, "step": 5},
         axis_order="tpcz",
         stage_positions=[(222, 1, 1), (111, 0, 0)],
     )
-    with qtbot.waitSignal(mmc.mda.events.sequenceFinished):
+    with qtbot.waitSignal(mmc.mda.events.sequenceFinished, timeout=2000):
         mmc.run_mda(sequence)
 
     layer_name = f"Exp_{sequence.uid}"

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -6,8 +6,8 @@ import pytest
 from pymmcore_plus.mda import MDAEngine
 from useq import MDASequence
 
+from micromanager_gui._gui_objects._mda_widget import SequenceMeta
 from micromanager_gui.main_window import MainWindow
-from micromanager_gui.multid_widget import SequenceMeta
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
@@ -23,11 +23,14 @@ def test_main_window_mda(main_window: MainWindow):
         channels=["DAPI", "FITC"],
     )
 
+    mmc = main_window._mmc
     main_window.mda.SEQUENCE_META[mda] = SequenceMeta(mode="mda")
+
+    mmc.mda.events.sequenceStarted.emit(mda)
 
     for event in mda:
         frame = np.random.rand(128, 128)
-        main_window._on_mda_frame(frame, event)
+        mmc.mda.events.frameReady.emit(frame, event)
     assert main_window.viewer.layers[-1].data.shape == (4, 2, 4, 128, 128)
 
 

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -6,7 +6,7 @@ import pytest
 from pymmcore_plus.mda import MDAEngine
 from useq import MDASequence
 
-from micromanager_gui._gui_objects._mda_widget import SequenceMeta
+from micromanager_gui import _mda
 from micromanager_gui.main_window import MainWindow
 
 if TYPE_CHECKING:
@@ -24,7 +24,7 @@ def test_main_window_mda(main_window: MainWindow):
     )
 
     mmc = main_window._mmc
-    main_window.mda.SEQUENCE_META[mda] = SequenceMeta(mode="mda")
+    _mda.SEQUENCE_META[mda] = _mda.SequenceMeta(mode="mda")
 
     mmc.mda.events.sequenceStarted.emit(mda)
 

--- a/tests/test_multid_widget.py
+++ b/tests/test_multid_widget.py
@@ -1,10 +1,10 @@
 from useq import MDASequence
 
-from micromanager_gui.multid_widget import MultiDWidget
+from micromanager_gui._gui_objects._mda_widget import MultiDWidget
 
 
 def test_multid_load_state(qtbot, global_mmcore):
-    wdg = MultiDWidget(global_mmcore)
+    wdg = MultiDWidget()
     qtbot.addWidget(wdg)
     assert wdg.stage_tableWidget.rowCount() == 0
     assert wdg.channel_tableWidget.rowCount() == 0


### PR DESCRIPTION
Building on #132 

Prior to this PR there was some complex coupling between the multi_d widget, the explore sample widget and the main window. The aim here is to simplify and break that up. My goals are:

1.  `explore_sample` and `mda_widget` do not have to know anything about napari  or eachother
      - They are each responsible only for constructing the appropriate MDASequence and  pause/stop
2. All interactions with Napari are confined to main_window widget
3. we also support displaying MDAs that initiated outside of napari-micromanager


(Partially done - but didn't want to lose this description that I wrote)