### PR TITLE
Ensure a new Core instance for each test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from typing import Tuple
 
 import numpy as np
 import pytest
+from pymmcore_plus import CMMCorePlus
 from useq import MDASequence
 
 from micromanager_gui import _core
@@ -15,7 +16,7 @@ ExplorerTuple = Tuple[MainWindow, MDASequence, SequenceMeta]
 
 @pytest.fixture(params=["local"])
 def global_mmcore(request):
-    _core._SESSION_CORE = None  # refresh singleton
+    _core._SESSION_CORE = CMMCorePlus()  # refresh singleton
     if request.param == "remote":
         from pymmcore_plus import server
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
-import os
 import uuid
+from pathlib import Path
 from typing import Tuple
 
 import numpy as np
@@ -24,7 +24,7 @@ def global_mmcore(request):
 
     mmc = _core.get_core_singleton(remote=request.param == "remote")
     if len(mmc.getLoadedDevices()) < 2:
-        mmc.loadSystemConfiguration()
+        mmc.loadSystemConfiguration(str(Path(__file__).parent / "test_config.cfg"))
     return mmc
 
 
@@ -32,7 +32,7 @@ def global_mmcore(request):
 def main_window(global_mmcore, make_napari_viewer):
     viewer = make_napari_viewer()
     win = MainWindow(viewer=viewer)
-    config_path = os.path.dirname(os.path.abspath(__file__)) + "/test_config.cfg"
+    config_path = str(Path(__file__).parent / "test_config.cfg")
     win.cfg_wdg.cfg_LineEdit.setText(config_path)
     win._mmc.loadSystemConfiguration(config_path)
     return win


### PR DESCRIPTION
Previously we were always getting the same core instance for each test due to the instancing of `CMMCorePlus.instance()`

this fixes that, and then fixes the test that then broke (which is also whats breaking #134 )

Pulling out of that to make things simpler to review