### PR TITLE
Live mode button widget

### DIFF
--- a/micromanager_gui/_core_widgets/_live_button.py
+++ b/micromanager_gui/_core_widgets/_live_button.py
@@ -1,11 +1,14 @@
 from typing import Optional, Tuple, Union
 
 from fonticon_mdi6 import MDI6
+
+# from numpy import ndarray
 from pymmcore_plus import CMMCorePlus
-from qtpy.QtCore import QSize, Qt
+from qtpy.QtCore import QSize, Qt, QTimer, Signal
 from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QApplication, QPushButton
 from superqt.fonticon import icon
+from superqt.utils import create_worker
 
 from micromanager_gui._core import get_core_singleton
 
@@ -22,10 +25,12 @@ COLOR_TYPE = Union[
 class LiveButton(QPushButton):
     """Create a live QPushButton"""
 
+    emitFrame = Signal()
+
     def __init__(
         self,
         mmcore: Optional[CMMCorePlus] = None,
-        button_text: Optional[str] = None,
+        button_text_on_off: Optional[tuple[str, str]] = (None, None),
         icon_size: Optional[int] = 30,
         icon_color_on_off: Optional[tuple[COLOR_TYPE, COLOR_TYPE]] = ("black", "black"),
     ) -> None:
@@ -33,9 +38,13 @@ class LiveButton(QPushButton):
         super().__init__()
 
         self._mmc = mmcore or get_core_singleton()
-        self.button_text = button_text
+        self.button_text_on = button_text_on_off[0]
+        self.button_text_off = button_text_on_off[1]
         self.icon_size = icon_size
-        self.icon_color = icon_color_on_off
+        self.icon_color_on = icon_color_on_off[0]
+        self.icon_color_off = icon_color_on_off[1]
+
+        self.streaming_timer = None
 
         self._mmc.events.systemConfigurationLoaded.connect(self._on_system_cfg_loaded)
         self._on_system_cfg_loaded()
@@ -43,10 +52,14 @@ class LiveButton(QPushButton):
 
         self._create_button()
 
+    def _emit(self):
+        create_worker(self.emitFrame.emit, _start_thread=True)
+
     def _create_button(self):
-        if self.button_text:
-            self.setText(self.button_text)
+        if self.button_text_on:
+            self.setText(self.button_text_on)
         self.set_icon_state(True)
+        self.clicked.connect(self.toggle_live)
 
     def _on_system_cfg_loaded(self):
         self.setEnabled(bool(self._mmc.getCameraDevice()))
@@ -59,10 +72,41 @@ class LiveButton(QPushButton):
     def set_icon_state(self, state: bool):
         """set the icon in the on or off state"""
         if state:
-            self.setIcon(icon(MDI6.video_outline, color=self.icon_color[0]))
+            self.setIcon(icon(MDI6.video_outline, color=self.icon_color_on))
+            if self.button_text_on:
+                self.setText(self.button_text_on)
+
         else:
-            self.setIcon(icon(MDI6.video_off_outline, color=self.icon_color[1]))
+            self.setIcon(icon(MDI6.video_off_outline, color=self.icon_color_off))
+            if self.button_text_off:
+                self.setText(self.button_text_off)
         self.setIconSize(QSize(self.icon_size, self.icon_size))
+
+    def start_live(self):
+        self._mmc.startContinuousSequenceAcquisition(self._mmc.getExposure())
+        self.streaming_timer = QTimer()
+        self.streaming_timer.timeout.connect(self._emit)
+        self.streaming_timer.start(self._mmc.getExposure())
+        self.set_icon_state(True)
+
+    def stop_live(self):
+        self._mmc.stopSequenceAcquisition()
+        if self.streaming_timer is not None:
+            self.streaming_timer.stop()
+            self.streaming_timer = None
+        self.set_icon_state(False)
+
+    def toggle_live(self, event=None):
+        if self.streaming_timer is None:
+
+            if not self._mmc.getChannelGroup():
+                return
+
+            self.start_live()
+            self.set_icon_state(False)
+        else:
+            self.stop_live()
+            self.set_icon_state(True)
 
 
 if __name__ == "__main__":

--- a/micromanager_gui/_core_widgets/_live_button.py
+++ b/micromanager_gui/_core_widgets/_live_button.py
@@ -1,0 +1,74 @@
+from typing import Optional, Tuple, Union
+
+from fonticon_mdi6 import MDI6
+from pymmcore_plus import CMMCorePlus
+from qtpy.QtCore import QSize, Qt
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QApplication, QPushButton
+from superqt.fonticon import icon
+
+from micromanager_gui._core import get_core_singleton
+
+COLOR_TYPE = Union[
+    QColor,
+    int,
+    str,
+    Qt.GlobalColor,
+    Tuple[int, int, int, int],
+    Tuple[int, int, int],
+]
+
+
+class LiveButton(QPushButton):
+    """Create a live QPushButton"""
+
+    def __init__(
+        self,
+        mmcore: Optional[CMMCorePlus] = None,
+        button_text: Optional[str] = None,
+        icon_size: Optional[int] = 30,
+        icon_color_on_off: Optional[tuple[COLOR_TYPE, COLOR_TYPE]] = ("black", "black"),
+    ) -> None:
+
+        super().__init__()
+
+        self._mmc = mmcore or get_core_singleton()
+        self.button_text = button_text
+        self.icon_size = icon_size
+        self.icon_color = icon_color_on_off
+
+        self._mmc.events.systemConfigurationLoaded.connect(self._on_system_cfg_loaded)
+        self._on_system_cfg_loaded()
+        self.destroyed.connect(self.disconnect)
+
+        self._create_button()
+
+    def _create_button(self):
+        if self.button_text:
+            self.setText(self.button_text)
+        self.set_icon_state(True)
+
+    def _on_system_cfg_loaded(self):
+        self.setEnabled(bool(self._mmc.getCameraDevice()))
+
+    def disconnect(self):
+        self._mmc.events.systemConfigurationLoaded.disconnect(
+            self._on_system_cfg_loaded
+        )
+
+    def set_icon_state(self, state: bool):
+        """set the icon in the on or off state"""
+        if state:
+            self.setIcon(icon(MDI6.video_outline, color=self.icon_color[0]))
+        else:
+            self.setIcon(icon(MDI6.video_off_outline, color=self.icon_color[1]))
+        self.setIconSize(QSize(self.icon_size, self.icon_size))
+
+
+if __name__ == "__main__":
+    import sys
+
+    app = QApplication(sys.argv)
+    win = LiveButton()
+    win.show()
+    sys.exit(app.exec_())

--- a/micromanager_gui/_core_widgets/_live_button.py
+++ b/micromanager_gui/_core_widgets/_live_button.py
@@ -23,9 +23,12 @@ COLOR_TYPE = Union[
 
 
 class LiveButton(QPushButton):
-    """Create a live QPushButton"""
+    """
+    Create a two-state (on-off) live mode QPushButton. When toggled on,
+    an empty signal is emitted ('_emitFrameSignal') through a QTimer.
+    """
 
-    emitFrame = Signal()
+    _emitFrameSignal = Signal()
 
     def __init__(
         self,
@@ -85,7 +88,7 @@ class LiveButton(QPushButton):
     def start_live(self):
         self._mmc.startContinuousSequenceAcquisition(self._mmc.getExposure())
         self.streaming_timer = QTimer()
-        self.streaming_timer.timeout.connect(self._emitFrame)
+        self.streaming_timer.timeout.connect(self._emitFrameSignal)
         self.streaming_timer.start(self._mmc.getExposure())
         self.set_icon_state(True)
 
@@ -96,11 +99,8 @@ class LiveButton(QPushButton):
             self.streaming_timer = None
         self.set_icon_state(False)
 
-    def toggle_live(self, event=None):
+    def toggle_live(self):
         if self.streaming_timer is None:
-
-            if not self._mmc.getChannelGroup():
-                return
 
             self.start_live()
             self.set_icon_state(False)

--- a/micromanager_gui/_core_widgets/_live_button.py
+++ b/micromanager_gui/_core_widgets/_live_button.py
@@ -90,14 +90,14 @@ class LiveButton(QPushButton):
         self.streaming_timer = QTimer()
         self.streaming_timer.timeout.connect(self._emitFrameSignal)
         self.streaming_timer.start(self._mmc.getExposure())
-        self.set_icon_state(True)
+        # self.set_icon_state(True)
 
     def stop_live(self):
         self._mmc.stopSequenceAcquisition()
         if self.streaming_timer is not None:
             self.streaming_timer.stop()
             self.streaming_timer = None
-        self.set_icon_state(False)
+        # self.set_icon_state(False)
 
     def toggle_live(self):
         if self.streaming_timer is None:

--- a/micromanager_gui/_core_widgets/_live_button.py
+++ b/micromanager_gui/_core_widgets/_live_button.py
@@ -52,7 +52,7 @@ class LiveButton(QPushButton):
 
         self._create_button()
 
-    def _emit(self):
+    def _emitFrame(self):
         create_worker(self.emitFrame.emit, _start_thread=True)
 
     def _create_button(self):
@@ -85,7 +85,7 @@ class LiveButton(QPushButton):
     def start_live(self):
         self._mmc.startContinuousSequenceAcquisition(self._mmc.getExposure())
         self.streaming_timer = QTimer()
-        self.streaming_timer.timeout.connect(self._emit)
+        self.streaming_timer.timeout.connect(self._emitFrame)
         self.streaming_timer.start(self._mmc.getExposure())
         self.set_icon_state(True)
 

--- a/micromanager_gui/_core_widgets/_live_button.py
+++ b/micromanager_gui/_core_widgets/_live_button.py
@@ -90,14 +90,12 @@ class LiveButton(QPushButton):
         self.streaming_timer = QTimer()
         self.streaming_timer.timeout.connect(self._emitFrameSignal)
         self.streaming_timer.start(self._mmc.getExposure())
-        # self.set_icon_state(True)
 
     def stop_live(self):
         self._mmc.stopSequenceAcquisition()
         if self.streaming_timer is not None:
             self.streaming_timer.stop()
             self.streaming_timer = None
-        # self.set_icon_state(False)
 
     def toggle_live(self):
         if self.streaming_timer is None:

--- a/micromanager_gui/_gui_objects/_tab_widget.py
+++ b/micromanager_gui/_gui_objects/_tab_widget.py
@@ -31,7 +31,7 @@ class MMTabWidget(QtW.QWidget):
 
         for attr, icon in [
             ("snap_Button", "cam.svg"),
-            ("live_Button", "vcam.svg"),
+            # ("live_Button", "vcam.svg"),
         ]:
             btn = getattr(self, attr)
             btn.setIcon(QIcon(str(ICONS / icon)))
@@ -96,7 +96,7 @@ class MMTabWidget(QtW.QWidget):
         # self.live_Button = QtW.QPushButton(text="Live")
         self.live_Button = LiveButton(
             button_text_on_off=("Live", "Stop"),
-            icon_size=30,
+            icon_size=45,
             icon_color_on_off=("green", "magenta"),
         )
         self.live_Button.setMinimumSize(QtCore.QSize(200, 50))

--- a/micromanager_gui/_gui_objects/_tab_widget.py
+++ b/micromanager_gui/_gui_objects/_tab_widget.py
@@ -5,6 +5,8 @@ from qtpy import QtWidgets as QtW
 from qtpy.QtCore import QSize
 from qtpy.QtGui import QIcon
 
+from .._core_widgets._live_button import LiveButton
+
 ICONS = Path(__file__).parent.parent / "icons"
 
 
@@ -91,7 +93,12 @@ class MMTabWidget(QtW.QWidget):
         self.snap_Button.setMinimumSize(QtCore.QSize(200, 50))
         self.snap_Button.setMaximumSize(QtCore.QSize(200, 50))
         self.btn_wdg_layout.addWidget(self.snap_Button)
-        self.live_Button = QtW.QPushButton(text="Live")
+        # self.live_Button = QtW.QPushButton(text="Live")
+        self.live_Button = LiveButton(
+            button_text_on_off=("Live", "Stop"),
+            icon_size=30,
+            icon_color_on_off=("green", "magenta"),
+        )
         self.live_Button.setMinimumSize(QtCore.QSize(200, 50))
         self.live_Button.setMaximumSize(QtCore.QSize(200, 50))
         self.btn_wdg_layout.addWidget(self.live_Button)

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -90,7 +90,7 @@ class MainWindow(MicroManagerWidget):
         self.stage_wdg.up_Button.clicked.connect(self.stage_z_up)
         self.stage_wdg.down_Button.clicked.connect(self.stage_z_down)
         self.tab_wdg.snap_Button.clicked.connect(self.snap)
-        self.tab_wdg.live_Button.emitFrame.connect(self._live)
+        self.tab_wdg.live_Button._emitFrameSignal.connect(self._live)
 
         # connect comboBox
         self.stage_wdg.focus_device_comboBox.currentTextChanged.connect(


### PR DESCRIPTION
Creating a new general purpose two-state (on-off) `Live` mode `QPushButton` widget.

When toggled on,  a signal is emitted (`_emitFrameSignal`) through a `QTimer`. In `main_window` the signal is connected to the `update_viewer` function.

@tlambert03 @ianhi Do you think it can be a valid solution?