### PR TITLE
dependencies: update pymmc+ and remove scikit-image

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,15 +29,13 @@ python_requires = >=3.8
 include_package_data = True
 install_requires =
     napari >=0.4.13
-    scikit-image
-    pymmcore-plus  @ git+https://github.com/tlambert03/pymmcore-plus
+    pymmcore-plus>=0.4.0
     useq-schema >=0.1.0
     superqt >=0.3.1
     tifffile
 
 [options.extras_require]
 testing =
-    pymmcore-plus  @ git+https://github.com/tlambert03/pymmcore-plus
     pytest
     pytest-qt
     pytest-cov


### PR DESCRIPTION
I don't think scikit-image is being used anywhere