### PR TITLE
create ExposureWidget as a core  widget + properly connect exposure signals

### DIFF
--- a/micromanager_gui/_core_widgets/__init__.py
+++ b/micromanager_gui/_core_widgets/__init__.py
@@ -1,5 +1,6 @@
 from ._device_widget import DeviceWidget, StateDeviceWidget
 from ._presets_widget import PresetsWidget
+from ._exposure_widget import DefaultCameraExposureWidget, ExposureWidget
 from ._property_browser import PropertyBrowser, PropertyTable
 from ._property_widget import PropertyWidget, make_property_value_widget
 
@@ -11,4 +12,6 @@ __all__ = [
     "PropertyBrowser",
     "PropertyTable",
     "PresetsWidget",
+    "ExposureWidget",
+    "DefaultCameraExposureWidget",
 ]

--- a/micromanager_gui/_core_widgets/__init__.py
+++ b/micromanager_gui/_core_widgets/__init__.py
@@ -1,6 +1,6 @@
 from ._device_widget import DeviceWidget, StateDeviceWidget
-from ._presets_widget import PresetsWidget
 from ._exposure_widget import DefaultCameraExposureWidget, ExposureWidget
+from ._presets_widget import PresetsWidget
 from ._property_browser import PropertyBrowser, PropertyTable
 from ._property_widget import PropertyWidget, make_property_value_widget
 

--- a/micromanager_gui/_core_widgets/_exposure_widget.py
+++ b/micromanager_gui/_core_widgets/_exposure_widget.py
@@ -9,6 +9,8 @@ from superqt.utils import signals_blocked
 if TYPE_CHECKING:
     from pymmcore_plus import CMMCorePlus
 
+from pymmcore import g_Keyword_CoreCamera, g_Keyword_CoreDevice
+
 from micromanager_gui import _core
 
 
@@ -79,9 +81,9 @@ class DefaultCameraExposureWidget(ExposureWidget):
         self, *, parent: Optional[Qt.QWidget] = None, core: Optional[CMMCorePlus] = None
     ):
         super().__init__(core=core)
-        self._mmc.events.devicePropertyChanged("Core", "Camera").connect(
-            self._camera_updated
-        )
+        self._mmc.events.devicePropertyChanged(
+            g_Keyword_CoreDevice, g_Keyword_CoreCamera
+        ).connect(self._camera_updated)
 
     def _camera_updated(self, value: str):
         # This will not always fire

--- a/micromanager_gui/_core_widgets/_exposure_widget.py
+++ b/micromanager_gui/_core_widgets/_exposure_widget.py
@@ -85,6 +85,15 @@ class DefaultCameraExposureWidget(ExposureWidget):
             g_Keyword_CoreDevice, g_Keyword_CoreCamera
         ).connect(self._camera_updated)
 
+    def setCamera(self, camera: str = None, force: bool = False):
+        if not force:
+            raise RuntimeError(
+                "Setting the camera on a DefaultCameraExposureWidget "
+                "may cause it to malfunction. Either use *force=True* "
+                " or create an ExposureWidget"
+            )
+        return super().setCamera(camera)
+
     def _camera_updated(self, value: str):
         # This will not always fire
         # see https://github.com/micro-manager/mmCoreAndDevices/issues/181

--- a/micromanager_gui/_core_widgets/_exposure_widget.py
+++ b/micromanager_gui/_core_widgets/_exposure_widget.py
@@ -86,6 +86,18 @@ class DefaultCameraExposureWidget(ExposureWidget):
         ).connect(self._camera_updated)
 
     def setCamera(self, camera: str = None, force: bool = False):
+        """
+        Set which camera this widget tracks. Using this on the
+        ``DefaultCameraExposureWidget``widget may cause unexpected
+        behavior, instead try to use an ``ExposureWidget``.
+
+        Parameters
+        ----------
+        camera : str
+            The camera device label. If None then use the current Camera device.
+        force : bool
+            Whether to force a change away from tracking the default camera.
+        """
         if not force:
             raise RuntimeError(
                 "Setting the camera on a DefaultCameraExposureWidget "

--- a/micromanager_gui/_core_widgets/_exposure_widget.py
+++ b/micromanager_gui/_core_widgets/_exposure_widget.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from qtpy import QtWidgets as QtW
+from qtpy.QtCore import Qt
+from superqt.utils import signals_blocked
+
+if TYPE_CHECKING:
+    from pymmcore_plus import CMMCorePlus
+
+from micromanager_gui import _core
+
+
+class ExposureWidget(QtW.QWidget):
+    def __init__(
+        self,
+        camera: str = None,
+        *,
+        parent: Optional[Qt.QWidget] = None,
+        core: Optional[CMMCorePlus] = None,
+    ):
+        super().__init__()
+        self._mmc = core or _core.get_core_singleton()
+        self._camera = camera or self._mmc.getCameraDevice()
+
+        self.label = QtW.QLabel()
+        self.label.setText(" ms")
+        self.label.setMaximumWidth(30)
+        self.spinBox = QtW.QDoubleSpinBox()
+        self.spinBox.setAlignment(Qt.AlignCenter)
+        self.spinBox.setMinimum(1.0)
+        self.spinBox.setMaximum(100000.0)
+        self.spinBox.setKeyboardTracking(False)
+        layout = QtW.QHBoxLayout()
+        layout.addWidget(self.spinBox)
+        layout.addWidget(self.label)
+        self.setLayout(layout)
+
+        self._on_load()
+        self._mmc.events.exposureChanged.connect(self._on_exp_changed)
+        self._mmc.events.systemConfigurationLoaded.connect(self._on_load)
+
+        self.spinBox.valueChanged.connect(self._mmc.setExposure)
+
+    def setCamera(self, camera: str = None):
+        """
+        Set which camera this widget tracks
+
+        Parameters
+        ----------
+        camera : str
+            The camera device label. If None then use the current Camera device.
+        """
+        orig_cam = self._camera
+        self._camera = camera or self._mmc.getCameraDevice()
+        if orig_cam != self._camera:
+            self._on_load()
+
+    def _on_load(self):
+        with signals_blocked(self.spinBox):
+            if self._camera and self._camera in self._mmc.getLoadedDevices():
+                self.setEnabled(True)
+                self.spinBox.setValue(self._mmc.getExposure(self._camera))
+            else:
+                self.setEnabled(False)
+
+    def _on_exp_changed(self, camera: str, exposure: float):
+        if camera == self._camera:
+            with signals_blocked(self.spinBox):
+                self.spinBox.setValue(exposure)
+
+    def _on_exp_set(self, exposure: float):
+        self._mmc.setExposure(self._camera, exposure)
+
+
+class DefaultCameraExposureWidget(ExposureWidget):
+    def __init__(
+        self, *, parent: Optional[Qt.QWidget] = None, core: Optional[CMMCorePlus] = None
+    ):
+        super().__init__(core=core)
+        self._mmc.events.devicePropertyChanged("Core", "Camera").connect(
+            self._camera_updated
+        )
+
+    def _camera_updated(self, value: str):
+        # This will not always fire
+        # see https://github.com/micro-manager/mmCoreAndDevices/issues/181
+        self._camera = value
+        # this will result in a double call of _on_load if this callback
+        # was triggered by a configuration load. But I don't see an easy way around that
+        # fortunately _on_load should be low cost
+        self._on_load()
+
+
+if __name__ == "__main__":
+    import sys
+
+    app = QtW.QApplication(sys.argv)
+    win = ExposureWidget()
+    win.show()
+    sys.exit(app.exec_())

--- a/micromanager_gui/_core_widgets/_exposure_widget.py
+++ b/micromanager_gui/_core_widgets/_exposure_widget.py
@@ -116,10 +116,13 @@ class DefaultCameraExposureWidget(ExposureWidget):
         self._on_load()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import sys
 
+    from pymmcore_plus import CMMCorePlus  # noqa
+
+    CMMCorePlus.instance().loadSystemConfiguration()
     app = QtW.QApplication(sys.argv)
-    win = ExposureWidget()
+    win = DefaultCameraExposureWidget()
     win.show()
     sys.exit(app.exec_())

--- a/micromanager_gui/_gui_objects/_tab_widget.py
+++ b/micromanager_gui/_gui_objects/_tab_widget.py
@@ -5,6 +5,8 @@ from qtpy import QtWidgets as QtW
 from qtpy.QtCore import QSize
 from qtpy.QtGui import QIcon
 
+from .._core_widgets import DefaultCameraExposureWidget
+
 ICONS = Path(__file__).parent.parent / "icons"
 
 
@@ -67,19 +69,12 @@ class MMTabWidget(QtW.QWidget):
         self.snap_live_tab_layout.addWidget(self.snap_channel_groupBox, 0, 0)
 
         # exposure in snap_live_tab
+        self.exposure_widget = DefaultCameraExposureWidget()
         self.exp_groupBox = QtW.QGroupBox()
         self.exp_groupBox.setMaximumHeight(70)
         self.exp_groupBox.setTitle("Exposure Time")
         self.exp_groupBox_layout = QtW.QHBoxLayout()
-        self.exp_label = QtW.QLabel()
-        self.exp_label.setText(" ms")
-        self.exp_label.setMaximumWidth(30)
-        self.exp_spinBox = QtW.QDoubleSpinBox()
-        self.exp_spinBox.setAlignment(QtCore.Qt.AlignCenter)
-        self.exp_spinBox.setMinimum(1.0)
-        self.exp_spinBox.setMaximum(100000.0)
-        self.exp_groupBox_layout.addWidget(self.exp_spinBox)
-        self.exp_groupBox_layout.addWidget(self.exp_label)
+        self.exp_groupBox_layout.addWidget(self.exposure_widget)
         self.exp_groupBox.setLayout(self.exp_groupBox_layout)
         self.snap_live_tab_layout.addWidget(self.exp_groupBox, 0, 1)
 

--- a/micromanager_gui/main_window.py
+++ b/micromanager_gui/main_window.py
@@ -69,7 +69,7 @@ class MainWindow(MicroManagerWidget):
         sig.systemConfigurationLoaded.connect(self._on_system_cfg_loaded)
         sig.XYStagePositionChanged.connect(self._on_xy_stage_position_changed)
         sig.stagePositionChanged.connect(self._on_stage_position_changed)
-        sig.exposureChanged.connect(self._on_exp_change)
+        sig.exposureChanged.connect(self._update_live_exp)
 
         # mda events
         self._mmc.mda.events.frameReady.connect(self._on_mda_frame)
@@ -102,10 +102,6 @@ class MainWindow(MicroManagerWidget):
             self.cam_wdg.cam_roi_combo,
             self.cam_wdg.crop_btn,
         )
-
-        # connect spinboxes
-        self.tab_wdg.exp_spinBox.valueChanged.connect(self._update_exp)
-        self.tab_wdg.exp_spinBox.setKeyboardTracking(False)
 
         # refresh options in case a config is already loaded by another remote
         if remote:
@@ -226,10 +222,11 @@ class MainWindow(MicroManagerWidget):
         )
 
     def start_live(self):
-        self._mmc.startContinuousSequenceAcquisition(self.tab_wdg.exp_spinBox.value())
+        exposure = self._mmc.getExposure()
+        self._mmc.startContinuousSequenceAcquisition(0)
         self.streaming_timer = QTimer()
         self.streaming_timer.timeout.connect(self.update_viewer)
-        self.streaming_timer.start(int(self.tab_wdg.exp_spinBox.value()))
+        self.streaming_timer.start(int(exposure))
         self.tab_wdg.live_Button.setText("Stop")
 
     def stop_live(self):
@@ -407,19 +404,11 @@ class MainWindow(MicroManagerWidget):
         self.explorer.x_lineEdit.setText(x)
         self.explorer.y_lineEdit.setText(y)
 
-    # exposure time
-    def _update_exp(self, exposure: float):
-        self._mmc.setExposure(exposure)
+    def _update_live_exp(self, camera: str, exposure: float):
         if self.streaming_timer:
             self.streaming_timer.setInterval(int(exposure))
             self._mmc.stopSequenceAcquisition()
             self._mmc.startContinuousSequenceAcquisition(exposure)
-
-    def _on_exp_change(self, camera: str, exposure: float):
-        with signals_blocked(self.tab_wdg.exp_spinBox):
-            self.tab_wdg.exp_spinBox.setValue(exposure)
-        if self.streaming_timer:
-            self.streaming_timer.setInterval(int(exposure))
 
     # channels
     def _refresh_channel_list(self):

--- a/tests/core_widgets/test_exposure_widget.py
+++ b/tests/core_widgets/test_exposure_widget.py
@@ -42,3 +42,7 @@ def test_exposure_widget(qtbot: QtBot):
     # should now be disabled.
     wdg.setCamera("blarg", force=True)
     assert not wdg.isEnabled()
+
+    with qtbot.wait_signal(CORE.events.exposureChanged):
+        wdg.spinBox.setValue(12)
+    assert CORE.getExposure() == 12

--- a/tests/core_widgets/test_exposure_widget.py
+++ b/tests/core_widgets/test_exposure_widget.py
@@ -43,6 +43,8 @@ def test_exposure_widget(qtbot: QtBot):
     wdg.setCamera("blarg", force=True)
     assert not wdg.isEnabled()
 
+    # reset the camera to a working one
+    CORE.setProperty("Core", "Camera", "Camera")
     with qtbot.wait_signal(CORE.events.exposureChanged):
         wdg.spinBox.setValue(12)
     assert CORE.getExposure() == 12

--- a/tests/core_widgets/test_exposure_widget.py
+++ b/tests/core_widgets/test_exposure_widget.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
 from pymmcore_plus import CMMCorePlus
 
 from micromanager_gui._core_widgets import DefaultCameraExposureWidget
@@ -32,4 +33,12 @@ def test_exposure_widget(qtbot: QtBot):
 
     # test updating cameraDevice
     CORE.setProperty("Core", "Camera", "")
+    assert not wdg.isEnabled()
+
+    with pytest.raises(RuntimeError):
+        wdg.setCamera("blarg")
+
+    # set to an invalid camera name
+    # should now be disabled.
+    wdg.setCamera("blarg", force=True)
     assert not wdg.isEnabled()

--- a/tests/core_widgets/test_exposure_widget.py
+++ b/tests/core_widgets/test_exposure_widget.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pymmcore_plus import CMMCorePlus
+
+from micromanager_gui._core_widgets import DefaultCameraExposureWidget
+
+if TYPE_CHECKING:
+    from pytestqt.qtbot import QtBot
+
+# not sure how else to parametrize the test without instantiating here at import ...
+CORE = CMMCorePlus()
+CORE.loadSystemConfiguration(Path(__file__).parent.parent / "test_config.cfg")
+
+
+def test_exposure_widget(qtbot: QtBot):
+    CORE.setExposure(15)
+    wdg = DefaultCameraExposureWidget(core=CORE)
+    qtbot.addWidget(wdg)
+
+    # check that it get's whatever core is set to.
+    assert wdg.spinBox.value() == 15
+    with qtbot.waitSignal(CORE.events.exposureChanged):
+        CORE.setExposure(30)
+    assert wdg.spinBox.value() == 30
+
+    with qtbot.wait_signal(CORE.events.exposureChanged):
+        wdg.spinBox.setValue(45)
+    assert CORE.getExposure() == 45
+
+    # test updating cameraDevice
+    CORE.setProperty("Core", "Camera", "")
+    assert not wdg.isEnabled()


### PR DESCRIPTION
Adds two new core widgets:

1. A general exposure widget that takes any camera neame
2. an exposure widget that follows the current camera device (`getCameraDevice`) as closely as possible. Though not perfectly, see https://github.com/micro-manager/mmCoreAndDevices/issues/181


There's also a bugfix in here. Previously if you loaded a config before opening napari then the exposure widget would not fill with the correct value - now it does.