### PR TITLE
Only fail tests on internal warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ napari.manifest =
 [tool:pytest]
 addopts = -v
 filterwarnings =
-    error
+    error:::micromanager_gui
     ignore::DeprecationWarning:ipykernel
     ignore:distutils Version classes are deprecated:DeprecationWarning:
 


### PR DESCRIPTION
Perhaps fixes #153  ... let's see.

The warning coming from napari was causing a fail here, due to test settings