### PR TITLE
update opengl git url

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'
         run: |
-          git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
+          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
 
       - name: Install dependencies


### PR DESCRIPTION
see https://stackoverflow.com/questions/70663523/the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported

should hopefully fix the failing windows tests


Example failure from https://github.com/tlambert03/napari-micromanager/runs/5592092388?check_suite_focus=true

![image](https://user-images.githubusercontent.com/10111092/158917943-44fcf85e-00a3-4905-bd33-7605b1d28bdc.png)
