### PR TITLE
fix DefaultCameraExposureWidget widgets layout

### DIFF
--- a/micromanager_gui/_gui_objects/_tab_widget.py
+++ b/micromanager_gui/_gui_objects/_tab_widget.py
@@ -59,7 +59,7 @@ class MMTabWidget(QtW.QWidget):
         self.snap_live_tab_layout = QtW.QGridLayout()
 
         wdg_sizepolicy = QtW.QSizePolicy(
-            QtW.QSizePolicy.Minimum, QtW.QSizePolicy.Expanding
+            QtW.QSizePolicy.Minimum, QtW.QSizePolicy.Minimum
         )
 
         # channel in snap_live_tab

--- a/micromanager_gui/_gui_objects/_tab_widget.py
+++ b/micromanager_gui/_gui_objects/_tab_widget.py
@@ -58,9 +58,13 @@ class MMTabWidget(QtW.QWidget):
         self.snap_live_tab = QtW.QWidget()
         self.snap_live_tab_layout = QtW.QGridLayout()
 
+        wdg_sizepolicy = QtW.QSizePolicy(
+            QtW.QSizePolicy.Minimum, QtW.QSizePolicy.Expanding
+        )
+
         # channel in snap_live_tab
         self.snap_channel_groupBox = QtW.QGroupBox()
-        self.snap_channel_groupBox.setMaximumHeight(70)
+        self.snap_channel_groupBox.setSizePolicy(wdg_sizepolicy)
         self.snap_channel_groupBox.setTitle("Channel")
         self.snap_channel_groupBox_layout = QtW.QHBoxLayout()
         self.snap_channel_comboBox = QtW.QComboBox()
@@ -71,7 +75,7 @@ class MMTabWidget(QtW.QWidget):
         # exposure in snap_live_tab
         self.exposure_widget = DefaultCameraExposureWidget()
         self.exp_groupBox = QtW.QGroupBox()
-        self.exp_groupBox.setMaximumHeight(70)
+        self.exp_groupBox.setSizePolicy(wdg_sizepolicy)
         self.exp_groupBox.setTitle("Exposure Time")
         self.exp_groupBox_layout = QtW.QHBoxLayout()
         self.exp_groupBox_layout.addWidget(self.exposure_widget)


### PR DESCRIPTION
minor fix of how the DefaultCameraExposureWidget (and the channel widget) are displayed. Setting the `SizePolicy` fixed this issue

<img width="590" alt="Screen Shot 2022-04-29 at 10 00 25 AM" src="https://user-images.githubusercontent.com/70725613/165959457-17561fd4-b28d-49f1-ac47-28c42df54974.png">
<img width="590" alt="Screen Shot 2022-04-29 at 9 59 49 AM" src="https://user-images.githubusercontent.com/70725613/165959453-696f5b00-ddac-497f-b204-580ecfd7dd2f.png">



