### PR TITLE
add ToolTip to any preset widget

### DIFF
--- a/micromanager_gui/_core_widgets/_presets_widget.py
+++ b/micromanager_gui/_core_widgets/_presets_widget.py
@@ -38,6 +38,9 @@ class PresetsWidget(QWidget):
 
         self._combo = QComboBox()
         self._combo.addItems(self._presets)
+        self._combo.setCurrentText(self._mmc.getCurrentConfig(self._group))
+        self._set_cfg_data_as_tool_tip(self._combo.currentText())
+        self._set_if_props_match_preset()
 
         self.setLayout(QHBoxLayout())
         self.layout().setContentsMargins(0, 0, 0, 0)
@@ -73,6 +76,7 @@ class PresetsWidget(QWidget):
     def _on_combo_changed(self, text: str) -> None:
         self._mmc.setConfig(self._group, text)
         self._combo.setStyleSheet("")
+        self._set_cfg_data_as_tool_tip(text)
 
     def _set_if_props_match_preset(self):
         """
@@ -91,6 +95,7 @@ class PresetsWidget(QWidget):
                 with signals_blocked(self._combo):
                     self._combo.setCurrentText(preset)
                     self._combo.setStyleSheet("")
+                    self._set_cfg_data_as_tool_tip(preset)
                     return
         # if None of the presets match the current system state
         self._combo.setStyleSheet("color: magenta;")
@@ -100,6 +105,7 @@ class PresetsWidget(QWidget):
             with signals_blocked(self._combo):
                 self._combo.setCurrentText(preset)
                 self._combo.setStyleSheet("")
+                self._set_cfg_data_as_tool_tip(preset)
         else:
             dev_prop_list = get_group_dev_prop(group, preset)
             if any(dev_prop for dev_prop in dev_prop_list if dev_prop in self.dev_prop):
@@ -121,10 +127,14 @@ class PresetsWidget(QWidget):
             if self._group not in self._mmc.getAvailableConfigGroups():
                 self._combo.addItem(f"No group named {self._group}.")
                 self._combo.setEnabled(False)
+                self._set_cfg_data_as_tool_tip("")
             else:
                 presets = self._mmc.getAvailableConfigs(self._group)
                 self._combo.addItems(presets)
                 self._combo.setEnabled(True)
+                self._combo.setCurrentText(self._mmc.getCurrentConfig(self._group))
+                self._set_cfg_data_as_tool_tip(self._combo.currentText())
+                self._set_if_props_match_preset()
 
     def value(self) -> str:
         return self._combo.currentText()
@@ -135,9 +145,16 @@ class PresetsWidget(QWidget):
                 f"{value!r} must be one of {self._mmc.getAvailableConfigs(self._group)}"
             )
         self._combo.setCurrentText(value)
+        self._set_cfg_data_as_tool_tip(value)
 
     def allowedValues(self) -> Tuple[str]:
         return tuple(self._combo.itemText(i) for i in range(self._combo.count()))
+
+    def _set_cfg_data_as_tool_tip(self, preset: str):
+        if not preset:
+            self._combo.setToolTip("")
+        else:
+            self._combo.setToolTip(str(self._mmc.getConfigData(self._group, preset)))
 
     def disconnect(self):
         self._mmc.events.configSet.disconnect(self._on_cfg_set)


### PR DESCRIPTION
I think it can be useful to know all the `properties` that have been assigned to a `group/preset` without using a "future" edit button/menu (we don't have it yet but I want to add it at some point) like in micromanager. 

This PR just adds `ToolTip` info depending on the `group-preset` `mmcore` `getConfigData()`.

It will work as in the examples below:

<img width="327" alt="Screen Shot 2022-05-02 at 11 47 42 PM" src="https://user-images.githubusercontent.com/70725613/166461867-c3f34591-e039-422f-a597-a8fce8ea998d.png">

<img width="561" alt="Screen Shot 2022-05-03 at 9 19 45 AM" src="https://user-images.githubusercontent.com/70725613/166461880-7d72781b-ea79-41cc-83b2-f60ffa5d16e2.png">

<img width="332" alt="Screen Shot 2022-05-03 at 9 20 30 AM" src="https://user-images.githubusercontent.com/70725613/166461892-3adbe9a6-2194-4e49-9cd4-89b0e13ac535.png">



