### PR TITLE
use build instead of setup.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,9 +75,9 @@ jobs:
         run: |
           git tag
           pip install --upgrade pip
-          pip install -U setuptools setuptools_scm wheel twine check-manifest
+          pip install -U setuptools twine check-manifest
           check-manifest
-          python setup.py sdist bdist_wheel
+          python -m build
 
       - name: twine check
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           git tag
           pip install --upgrade pip
-          pip install -U setuptools twine check-manifest
+          pip install -U build twine check-manifest
           check-manifest
           python -m build
 


### PR DESCRIPTION
Release failed due to this https://github.com/tlambert03/napari-micromanager/runs/6515242667?check_suite_focus=true

attn: @tlambert03 