### PR TITLE
add mda-simulator to launch_dev

### DIFF
--- a/launch-dev.py
+++ b/launch-dev.py
@@ -3,16 +3,29 @@ from pathlib import Path
 import napari
 from useq import MDASequence
 
+try:
+    from mda_simulator.mmcore import FakeDemoCamera
+except ModuleNotFoundError:
+    FakeDemoCamera = None
+
 v = napari.Viewer()
 dw, main_window = v.window.add_plugin_dock_widget("napari-micromanager")
 
 core = main_window._mmc
 core.loadSystemConfiguration(str(Path(__file__).parent / "tests" / "test_config.cfg"))
 
+if FakeDemoCamera is not None:
+    # override snap to look at more realistic images from a microscoppe
+    # with underlying random walk simulation of spheres
+    # These act as though "Cy5" is BF and other channels are fluorescent
+    fake_cam = FakeDemoCamera(timing=2)
+    # make sure we start in a valid channel group
+    core.setConfig("Channel", "Cy5")
+
 sequence = MDASequence(
-    channels=["Cy5", {"config": "FITC", "exposure": 50}],
-    time_plan={"interval": 2, "loops": 5},
-    z_plan={"range": 4, "step": 0.5},
+    channels=["Cy5", {"config": "FITC", "exposure": 10}],
+    time_plan={"interval": 10, "loops": 5},
+    z_plan={"range": 50, "step": 10},
     axis_order="tpcz",
     stage_positions=[(222, 1, 1), (111, 0, 0)],
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,8 @@ pyqt5 =
     PyQt5
 pyside2 =
     PySide2
+dev =
+    mda-simulator
 
 [options.entry_points]
 napari.manifest =


### PR DESCRIPTION
Optionally uses [mda-simulator](https://mda-simulator.readthedocs.io/en/latest/index.html) in the launch dev script. This is nice because it gives more realistic images than the default demo camera. In particular there is an underlying simulation so XYZ position has an effect on the images generated, also fwiw it looks more similar to real biological images.